### PR TITLE
fix: 업로드 파일 크기제한 증가

### DIFF
--- a/src/main/java/com/gbsw/messiofcoding/infra/s3/S3Service.java
+++ b/src/main/java/com/gbsw/messiofcoding/infra/s3/S3Service.java
@@ -78,7 +78,7 @@ public class S3Service {
             throw new CustomException(ErrorCode.INVALID_IMAGE_TYPE);
         }
 
-        long MAX_SIZE = 10 * 1024 * 1024L;
+        long MAX_SIZE = 20 * 1024 * 1024L;
         if (file.getSize() > MAX_SIZE) {
             throw new CustomException(ErrorCode.IMAGE_SIZE_EXCEEDED);
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,11 @@ spring:
   config:
     import: application-secret.yml
 
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 20MB
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
 


### PR DESCRIPTION
### Type of PR
fix
### Changes
- 기존 업로드 파일 크기 제한을 10MB에서 20MB로 증가
- Spring Multipart 제한도 20MB로 설정
### Additional
close #10 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 파일 업로드 크기 제한을 10MB에서 20MB로 증가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->