### PR TITLE
feat: 오늘 데일리 앨범 조회 API 추가

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/controller/AlbumController.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/controller/AlbumController.java
@@ -1,6 +1,7 @@
 package com.gbsw.snapy.domain.albums.controller;
 
 import com.gbsw.snapy.domain.albums.dto.request.AlbumUploadRequest;
+import com.gbsw.snapy.domain.albums.dto.response.AlbumTodayResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumUploadResponse;
 import com.gbsw.snapy.domain.albums.service.AlbumService;
 import com.gbsw.snapy.global.common.ApiResponse;
@@ -24,6 +25,14 @@ public class AlbumController {
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
         AlbumUploadResponse response = albumService.upload(request, principal.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/today")
+    public ResponseEntity<ApiResponse<AlbumTodayResponse>> getToday(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        AlbumTodayResponse response = albumService.getTodayAlbum(principal.getId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/albums/dto/response/AlbumTodayResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/dto/response/AlbumTodayResponse.java
@@ -1,0 +1,30 @@
+package com.gbsw.snapy.domain.albums.dto.response;
+
+import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
+import com.gbsw.snapy.domain.albums.entity.DailyAlbum;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record AlbumTodayResponse(
+        Long albumId,
+        LocalDate albumDate,
+        int photoCount,
+        List<AlbumPhotoSet> photos
+) {
+    public static AlbumTodayResponse of(DailyAlbum album, List<AlbumPhotoSet> photos) {
+        return new AlbumTodayResponse(
+                album.getId(),
+                album.getAlbumDate(),
+                album.getPhotoCount(),
+                photos
+        );
+    }
+
+    public record AlbumPhotoSet(
+            AlbumPhotoType type,
+            String frontImageUrl,
+            String backImageUrl
+    ) {
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -1,6 +1,7 @@
 package com.gbsw.snapy.domain.albums.service;
 
 import com.gbsw.snapy.domain.albums.dto.request.AlbumUploadRequest;
+import com.gbsw.snapy.domain.albums.dto.response.AlbumTodayResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumUploadResponse;
 import com.gbsw.snapy.domain.albums.entity.AlbumPhoto;
 import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
@@ -24,7 +25,10 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -92,6 +96,54 @@ public class AlbumService {
         );
 
         return AlbumUploadResponse.from(album, request.getType());
+    }
+
+    @Transactional(readOnly = true)
+    public AlbumTodayResponse getTodayAlbum(Long userId) {
+        LocalDate today = LocalDate.now();
+        DailyAlbum album = dailyAlbumRepository.findByUserIdAndAlbumDate(userId, today)
+                .orElse(null);
+        if (album == null) {
+            return null;
+        }
+
+        List<AlbumPhoto> albumPhotos = albumPhotoRepository.findByAlbumIdOrderByTypeAsc(album.getId());
+        if (albumPhotos.isEmpty()) {
+            return AlbumTodayResponse.of(album, List.of());
+        }
+
+        List<Long> photoIds = albumPhotos.stream().map(AlbumPhoto::getPhotoId).toList();
+        Map<Long, Photo> photoById = new HashMap<>();
+        for (Photo photo : photoRepository.findAllById(photoIds)) {
+            photoById.put(photo.getId(), photo);
+        }
+        if (photoById.size() != photoIds.size()) {
+            throw new CustomException(ErrorCode.IMAGE_NOT_FOUND);
+        }
+
+        Map<AlbumPhotoType, String> frontUrls = new EnumMap<>(AlbumPhotoType.class);
+        Map<AlbumPhotoType, String> backUrls = new EnumMap<>(AlbumPhotoType.class);
+        for (AlbumPhoto ap : albumPhotos) {
+            Photo photo = photoById.get(ap.getPhotoId());
+            if (ap.getSide() == PhotoType.FRONT) {
+                frontUrls.put(ap.getType(), photo.getImageUrl());
+            } else {
+                backUrls.put(ap.getType(), photo.getImageUrl());
+            }
+        }
+
+        List<AlbumTodayResponse.AlbumPhotoSet> sets = new ArrayList<>();
+        for (AlbumPhotoType type : AlbumPhotoType.values()) {
+            if (frontUrls.containsKey(type) || backUrls.containsKey(type)) {
+                sets.add(new AlbumTodayResponse.AlbumPhotoSet(
+                        type,
+                        frontUrls.get(type),
+                        backUrls.get(type)
+                ));
+            }
+        }
+
+        return AlbumTodayResponse.of(album, sets);
     }
 
     @Transactional


### PR DESCRIPTION
### Type of PR
feat
### Changes
- GET /api/albums/today 엔드포인트 추가
- AlbumTodayResponse DTO 추가 (시간대별 front/back 이미지 묶음)
- AlbumService.getTodayAlbum 추가, photoIds 일괄 조회로 N+1 방지
- 오늘 앨범이 없는 경우 200 + data: null 응답
### Additional
close #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 오늘의 앨범 조회 API 추가
  * 인증된 사용자가 오늘의 앨범 정보와 사진을 조회할 수 있는 새로운 엔드포인트 추가
  * 사진 정보에 유형별로 구성된 앞면 및 뒷면 이미지 URL 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->