### PR TITLE
feat: 상세조회 공개 범위 변경

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -132,7 +132,7 @@ public class AlbumService {
         DailyAlbum album = dailyAlbumRepository.findById(albumId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
 
-        if (!album.getUserId().equals(userId)) {
+        if (!album.getUserId().equals(userId) && album.getStatus() != AlbumStatus.PUBLISHED) {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
 


### PR DESCRIPTION
### Type of PR
feat
### Changes
- 본인은 항상, 타인은 PUBLISHED일 때만 조회 가능
### Additional
- 친구 관계 검증은 friend 도메인 추가 후 별도 PR에서 적용 예정
- close #37 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 앨범 상세 조회 시 접근 제어가 개선되었습니다. 앨범 소유자는 미공개 앨범을 조회할 수 있으며, 공개된 앨범은 모든 사용자가 접근할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->