### PR TITLE
feat: 데일리 앨범 업로드 시 스토리 자동 생성

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -19,6 +19,9 @@ import com.gbsw.snapy.domain.photos.repository.PhotoRepository;
 import com.gbsw.snapy.domain.photos.service.PhotoService;
 import com.gbsw.snapy.global.exception.CustomException;
 import com.gbsw.snapy.global.exception.ErrorCode;
+import com.gbsw.snapy.domain.stories.entity.Story;
+import com.gbsw.snapy.domain.stories.repository.StoryRepository;
+import com.gbsw.snapy.domain.stories.service.StoryService;
 import com.gbsw.snapy.infra.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,6 +50,8 @@ public class AlbumService {
     private final PhotoService photoService;
     private final PhotoRepository photoRepository;
     private final S3Service s3Service;
+    private final StoryService storyService;
+    private final StoryRepository storyRepository;
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
     @Transactional
@@ -107,6 +112,10 @@ public class AlbumService {
                         .side(PhotoType.BACK)
                         .build()
         );
+
+        Story story = storyRepository.findByUserIdAndAlbumId(userId, album.getId())
+                .orElseGet(() -> storyService.createStory(userId, album.getId()));
+        storyService.addPhotos(story.getId(), frontPhoto.photoId(), backPhoto.photoId(), request.getType());
 
         return AlbumUploadResponse.from(album, request.getType());
     }

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDate;
@@ -113,8 +114,14 @@ public class AlbumService {
                         .build()
         );
 
-        Story story = storyRepository.findByUserIdAndAlbumId(userId, album.getId())
-                .orElseGet(() -> storyService.createStory(userId, album.getId()));
+        Story story;
+        try {
+            story = storyRepository.findByUserIdAndAlbumId(userId, album.getId())
+                    .orElseGet(() -> storyService.createStory(userId, album.getId()));
+        } catch (DataIntegrityViolationException e) {
+            story = storyRepository.findByUserIdAndAlbumId(userId, album.getId())
+                    .orElseThrow(() -> e);
+        }
         storyService.addPhotos(story.getId(), frontPhoto.photoId(), backPhoto.photoId(), request.getType());
 
         return AlbumUploadResponse.from(album, request.getType());

--- a/src/main/java/com/gbsw/snapy/domain/stories/entity/Story.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/entity/Story.java
@@ -1,0 +1,51 @@
+package com.gbsw.snapy.domain.stories.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "stories", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "album_id"})
+})
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Story {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "album_id", nullable = false)
+    private Long albumId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private StoryStatus status = StoryStatus.ACTIVE;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void expire() {
+        this.status = StoryStatus.EXPIRED;
+    }
+
+    public boolean isExpired() {
+        return this.status == StoryStatus.EXPIRED;
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/stories/entity/StoryPhoto.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/entity/StoryPhoto.java
@@ -1,0 +1,45 @@
+package com.gbsw.snapy.domain.stories.entity;
+
+import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
+import com.gbsw.snapy.domain.photos.entity.PhotoType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "story_photos", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"story_id", "type", "side"})
+})
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class StoryPhoto {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "story_id", nullable = false)
+    private Long storyId;
+
+    @Column(name = "photo_id", nullable = false)
+    private Long photoId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AlbumPhotoType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PhotoType side;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/stories/entity/StoryStatus.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/entity/StoryStatus.java
@@ -1,0 +1,6 @@
+package com.gbsw.snapy.domain.stories.entity;
+
+public enum StoryStatus {
+    ACTIVE,
+    EXPIRED
+}

--- a/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryPhotoRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryPhotoRepository.java
@@ -1,0 +1,7 @@
+package com.gbsw.snapy.domain.stories.repository;
+
+import com.gbsw.snapy.domain.stories.entity.StoryPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoryPhotoRepository extends JpaRepository<StoryPhoto, Long> {
+}

--- a/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryRepository.java
@@ -1,0 +1,11 @@
+package com.gbsw.snapy.domain.stories.repository;
+
+import com.gbsw.snapy.domain.stories.entity.Story;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StoryRepository extends JpaRepository<Story, Long> {
+
+    Optional<Story> findByUserIdAndAlbumId(Long userId, Long albumId);
+}

--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -8,6 +8,7 @@ import com.gbsw.snapy.domain.stories.repository.StoryPhotoRepository;
 import com.gbsw.snapy.domain.stories.repository.StoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -21,7 +22,7 @@ public class StoryService {
     private final StoryPhotoRepository storyPhotoRepository;
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Story createStory(Long userId, Long albumId) {
         LocalDateTime nowKst = LocalDateTime.now(KST_ZONE);
 

--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -1,0 +1,58 @@
+package com.gbsw.snapy.domain.stories.service;
+
+import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
+import com.gbsw.snapy.domain.photos.entity.PhotoType;
+import com.gbsw.snapy.domain.stories.entity.Story;
+import com.gbsw.snapy.domain.stories.entity.StoryPhoto;
+import com.gbsw.snapy.domain.stories.repository.StoryPhotoRepository;
+import com.gbsw.snapy.domain.stories.repository.StoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+public class StoryService {
+
+    private final StoryRepository storyRepository;
+    private final StoryPhotoRepository storyPhotoRepository;
+    private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
+
+    @Transactional
+    public Story createStory(Long userId, Long albumId) {
+        LocalDateTime nowKst = LocalDateTime.now(KST_ZONE);
+
+        return storyRepository.save(
+                Story.builder()
+                        .userId(userId)
+                        .albumId(albumId)
+                        .expiresAt(nowKst.plusHours(24))
+                        .build()
+        );
+    }
+
+    @Transactional
+    public void addPhotos(Long storyId, Long frontPhotoId, Long backPhotoId,
+                          AlbumPhotoType type) {
+        storyPhotoRepository.save(
+                StoryPhoto.builder()
+                        .storyId(storyId)
+                        .photoId(frontPhotoId)
+                        .type(type)
+                        .side(PhotoType.FRONT)
+                        .build()
+        );
+
+        storyPhotoRepository.save(
+                StoryPhoto.builder()
+                        .storyId(storyId)
+                        .photoId(backPhotoId)
+                        .type(type)
+                        .side(PhotoType.BACK)
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
### Type of PR
feat
### Changes
- Story, StoryPhoto 엔티티 및 StoryStatus enum 추가 (ACTIVE / EXPIRED)
- AlbumService.upload()에서 앨범 사진 업로드 시 스토리 자동 생성/사진 추가 연동
### Additional
- 스토리는 하루에 1개 (DailyAlbum 단위), 사진 업로드마다 StoryPhoto가 추가되는 구조
- close #43 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 앨범 업로드 시 자동으로 스토리가 생성됩니다.
  * 업로드한 앨범 사진(앞/뒤)이 해당 스토리에 연결됩니다.
  * 스토리는 생성 시점으로부터 24시간 후 자동으로 만료됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->