### PR TITLE
feat: 캘린더 썸네일 조회 API 구현

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/controller/AlbumController.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/controller/AlbumController.java
@@ -42,6 +42,14 @@ public class AlbumController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @GetMapping("/calendar")
+    public ResponseEntity<ApiResponse<List<AlbumListResponse>>> getCalendarThumbnails(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        List<AlbumListResponse> response = albumService.getCalendarThumbnails(principal.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
     @GetMapping("/today")
     public ResponseEntity<ApiResponse<AlbumTodayResponse>> getToday(
             @AuthenticationPrincipal CustomUserPrincipal principal

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -252,6 +252,55 @@ public class AlbumService {
         return result;
     }
 
+    @Transactional(readOnly = true)
+    public List<AlbumListResponse> getCalendarThumbnails(Long userId) {
+        LocalDate today = LocalDate.now(KST_ZONE);
+        LocalDate fiveMonthsAgo = today.minusMonths(5).withDayOfMonth(1);
+
+        List<DailyAlbum> albums = dailyAlbumRepository
+                .findByUserIdAndAlbumDateBetweenOrderByAlbumDateDesc(userId, fiveMonthsAgo, today);
+        if (albums.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> albumIds = albums.stream().map(DailyAlbum::getId).toList();
+        List<AlbumPhoto> frontPhotos = albumPhotoRepository
+                .findByAlbumIdInAndSide(albumIds, PhotoType.FRONT);
+
+        Map<Long, AlbumPhoto> thumbnailByAlbumId = new HashMap<>();
+        for (AlbumPhoto ap : frontPhotos) {
+            AlbumPhoto current = thumbnailByAlbumId.get(ap.getAlbumId());
+            if (current == null || ap.getType().ordinal() < current.getType().ordinal()) {
+                thumbnailByAlbumId.put(ap.getAlbumId(), ap);
+            }
+        }
+
+        List<Long> photoIds = thumbnailByAlbumId.values().stream()
+                .map(AlbumPhoto::getPhotoId)
+                .toList();
+        Map<Long, Photo> photoById = new HashMap<>();
+        if (!photoIds.isEmpty()) {
+            for (Photo photo : photoRepository.findAllById(photoIds)) {
+                photoById.put(photo.getId(), photo);
+            }
+            if (photoById.size() != photoIds.size()) {
+                throw new CustomException(ErrorCode.IMAGE_NOT_FOUND);
+            }
+        }
+
+        List<AlbumListResponse> result = new ArrayList<>(albums.size());
+        for (DailyAlbum album : albums) {
+            AlbumPhoto thumbnail = thumbnailByAlbumId.get(album.getId());
+            String thumbnailUrl = null;
+            if (thumbnail != null) {
+                Photo photo = photoById.get(thumbnail.getPhotoId());
+                thumbnailUrl = photo.getImageUrl();
+            }
+            result.add(AlbumListResponse.of(album, thumbnailUrl));
+        }
+        return result;
+    }
+
     @Transactional
     public AlbumPublishResponse publishAlbum(Long albumId, Long userId) {
         DailyAlbum album = dailyAlbumRepository.findByIdForUpdate(albumId)


### PR DESCRIPTION
### Type of PR
feat
### Changes
- GET /api/albums/calendar 엔드포인트 추가
- 오늘 기준 5개월 전 1일부터 오늘까지의 앨범 썸네일 목록 반환
- 기존 AlbumListResponse 재사용 (albumId, albumDate, thumbnailUrl)
### Additional
- 기존 월별 조회(getAlbumsByMonth)와 동일한 썸네일 선택 로직 사용
- close #52 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
- 지난 5개월간의 앨범 썸네일을 달력 형식으로 조회할 수 있는 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->