### PR TITLE
refactor: 로그인시 refreshToken도 body에 함께 반환

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/gbsw/snapy/domain/auth/controller/AuthController.java
@@ -10,6 +10,7 @@ import com.gbsw.snapy.domain.auth.service.AuthService;
 import com.gbsw.snapy.global.security.jwt.JwtProperties;
 import com.gbsw.snapy.global.common.ApiResponse;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -35,9 +36,15 @@ public class AuthController {
     @PostMapping("login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(
             @Valid @RequestBody LoginRequest dto,
+            HttpServletRequest request,
             HttpServletResponse response
     ) {
         LoginServiceResult result = authService.login(dto);
+        boolean isApp = "app".equals(request.getHeader("X-Client-Type"));
+
+        if (isApp) {
+            return ResponseEntity.ok(ApiResponse.success(new LoginResponse(result.accessToken(), result.refreshToken())));
+        }
 
         Cookie cookie = new Cookie("refreshToken", result.refreshToken());
         cookie.setHttpOnly(true);
@@ -46,31 +53,38 @@ public class AuthController {
         cookie.setMaxAge((int) (jwtProperties.getRefreshTokenExpiration() / 1000));
         response.addCookie(cookie);
 
-        return ResponseEntity.ok(ApiResponse.success(new LoginResponse(result.accessToken(), result.refreshToken())));
+        return ResponseEntity.ok(ApiResponse.success(new LoginResponse(result.accessToken(), null)));
     }
 
     @PostMapping("refresh-accesstoken")
     public ResponseEntity<ApiResponse<RefreshAccessTokenResponse>> refreshAccessToken(
-            @CookieValue(name = "refreshToken", required = false) String refreshToken
+            @RequestHeader(value = "X-Client-Type", required = false) String clientType,
+            @RequestHeader(value = "X-Refresh-Token", required = false) String appRefreshToken,
+            @CookieValue(name = "refreshToken", required = false) String cookieRefreshToken
     ) {
+        String refreshToken = "app".equals(clientType) ? appRefreshToken : cookieRefreshToken;
         RefreshAccessTokenResponse rs = authService.refreshAcessToken(refreshToken);
         return ResponseEntity.ok(ApiResponse.success(rs));
     }
 
     @PostMapping("logout")
     public ResponseEntity<ApiResponse<Void>> logout(
-            @CookieValue(name = "refreshToken", required = false) String refreshToken,
+            @RequestHeader(value = "X-Client-Type", required = false) String clientType,
+            @RequestHeader(value = "X-Refresh-Token", required = false) String appRefreshToken,
+            @CookieValue(name = "refreshToken", required = false) String cookieRefreshToken,
             HttpServletResponse response
     ) {
+        String refreshToken = "app".equals(clientType) ? appRefreshToken : cookieRefreshToken;
         authService.logout(refreshToken);
 
-        // 클라이언트 RefreshToken 쿠키 만료시키기
-        Cookie cookie = new Cookie("refreshToken", null);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(0);
-        response.addCookie(cookie);
+        if (!"app".equals(clientType)) {
+            Cookie cookie = new Cookie("refreshToken", null);
+            cookie.setHttpOnly(true);
+            cookie.setSecure(true);
+            cookie.setPath("/");
+            cookie.setMaxAge(0);
+            response.addCookie(cookie);
+        }
 
         return ResponseEntity.ok(ApiResponse.success(null));
     }

--- a/src/main/java/com/gbsw/snapy/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/gbsw/snapy/domain/auth/controller/AuthController.java
@@ -46,7 +46,7 @@ public class AuthController {
         cookie.setMaxAge((int) (jwtProperties.getRefreshTokenExpiration() / 1000));
         response.addCookie(cookie);
 
-        return ResponseEntity.ok(ApiResponse.success(new LoginResponse(result.accessToken())));
+        return ResponseEntity.ok(ApiResponse.success(new LoginResponse(result.accessToken(), result.refreshToken())));
     }
 
     @PostMapping("refresh-accesstoken")

--- a/src/main/java/com/gbsw/snapy/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/auth/dto/response/LoginResponse.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class LoginResponse {
     private String accessToken;
+    private String refreshToken;
 }


### PR DESCRIPTION
### Type of PR
refactor

### Changes
로그인시 refreshToken이 body에 함께 반환되도록 변경

### Additional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그인 시 클라이언트 유형에 따라 리프레시 토큰을 응답 본문 또는 안전한 HTTP 전용 쿠키로 전달합니다.
  * 액세스 토큰 갱신과 로그아웃 시 클라이언트 유형에 따라 헤더 또는 쿠키에서 리프레시 토큰을 읽어 처리합니다.

* **변경 사항**
  * 로그인 응답에 리프레시 토큰 필드가 추가되어 토큰 전달 방식이 분기됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->