### PR TITLE
feat: 앨범 상세/오늘 조회 응답에 촬영 시간 추가

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/dto/response/AlbumDetailResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/dto/response/AlbumDetailResponse.java
@@ -4,6 +4,7 @@ import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
 import com.gbsw.snapy.domain.albums.entity.DailyAlbum;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record AlbumDetailResponse(
@@ -24,7 +25,8 @@ public record AlbumDetailResponse(
     public record AlbumPhotoSet(
             AlbumPhotoType type,
             String frontImageUrl,
-            String backImageUrl
+            String backImageUrl,
+            LocalDateTime createdAt
     ) {
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/albums/dto/response/AlbumTodayResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/dto/response/AlbumTodayResponse.java
@@ -4,6 +4,7 @@ import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
 import com.gbsw.snapy.domain.albums.entity.DailyAlbum;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record AlbumTodayResponse(
@@ -24,7 +25,8 @@ public record AlbumTodayResponse(
     public record AlbumPhotoSet(
             AlbumPhotoType type,
             String frontImageUrl,
-            String backImageUrl
+            String backImageUrl,
+            LocalDateTime createdAt
     ) {
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -32,6 +32,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -138,7 +139,7 @@ public class AlbumService {
 
         List<PhotoSetView> sets = loadPhotoSets(album.getId());
         List<AlbumTodayResponse.AlbumPhotoSet> mapped = sets.stream()
-                .map(s -> new AlbumTodayResponse.AlbumPhotoSet(s.type(), s.frontImageUrl(), s.backImageUrl()))
+                .map(s -> new AlbumTodayResponse.AlbumPhotoSet(s.type(), s.frontImageUrl(), s.backImageUrl(), s.createdAt()))
                 .toList();
         return AlbumTodayResponse.of(album, mapped);
     }
@@ -154,7 +155,7 @@ public class AlbumService {
 
         List<PhotoSetView> sets = loadPhotoSets(album.getId());
         List<AlbumDetailResponse.AlbumPhotoSet> mapped = sets.stream()
-                .map(s -> new AlbumDetailResponse.AlbumPhotoSet(s.type(), s.frontImageUrl(), s.backImageUrl()))
+                .map(s -> new AlbumDetailResponse.AlbumPhotoSet(s.type(), s.frontImageUrl(), s.backImageUrl(), s.createdAt()))
                 .toList();
         return AlbumDetailResponse.of(album, mapped);
     }
@@ -176,10 +177,12 @@ public class AlbumService {
 
         Map<AlbumPhotoType, String> frontUrls = new EnumMap<>(AlbumPhotoType.class);
         Map<AlbumPhotoType, String> backUrls = new EnumMap<>(AlbumPhotoType.class);
+        Map<AlbumPhotoType, LocalDateTime> createdAts = new EnumMap<>(AlbumPhotoType.class);
         for (AlbumPhoto ap : albumPhotos) {
             Photo photo = photoById.get(ap.getPhotoId());
             if (ap.getSide() == PhotoType.FRONT) {
                 frontUrls.put(ap.getType(), photo.getImageUrl());
+                createdAts.put(ap.getType(), photo.getCreatedAt());
             } else {
                 backUrls.put(ap.getType(), photo.getImageUrl());
             }
@@ -188,13 +191,15 @@ public class AlbumService {
         List<PhotoSetView> sets = new ArrayList<>();
         for (AlbumPhotoType type : AlbumPhotoType.values()) {
             if (frontUrls.containsKey(type) || backUrls.containsKey(type)) {
-                sets.add(new PhotoSetView(type, frontUrls.get(type), backUrls.get(type)));
+                sets.add(new PhotoSetView(type, frontUrls.get(type), backUrls.get(type),
+                        createdAts.get(type)));
             }
         }
         return sets;
     }
 
-    private record PhotoSetView(AlbumPhotoType type, String frontImageUrl, String backImageUrl) {
+    private record PhotoSetView(AlbumPhotoType type, String frontImageUrl, String backImageUrl,
+                                    LocalDateTime createdAt) {
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
### Type of PR
feat
### Changes
- AlbumDetailResponse, AlbumTodayResponse의 AlbumPhotoSet에 createdAt 필드 추가
- Photo.createdAt(FRONT 사진 기준)을 촬영 시간으로 사용
### Additional
- close #55 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 앨범 사진에 생성 일시 정보 추가: 각 사진의 생성 날짜와 시간이 앨범 상세 정보 및 오늘의 앨범에 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->