### PR TITLE
feat: 친구 스토리 목록/상세 조회 API 구현

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/friends/repository/FriendRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/friends/repository/FriendRepository.java
@@ -33,4 +33,9 @@ public interface FriendRepository extends JpaRepository<Friend, FriendId> {
                    "WHERE (f1.user_a_id = :userAId OR f1.user_b_id = :userAId) " +
                    "AND (f2.user_a_id = :userBId OR f2.user_b_id = :userBId)", nativeQuery = true)
     List<FriendUserProjection> findMutualFriends(@Param("userAId") Long userAId, @Param("userBId") Long userBId);
+
+    @Query(value = "SELECT IF(f.user_a_id = :userId, f.user_b_id, f.user_a_id) " +
+                   "FROM friends f " +
+                   "WHERE f.user_a_id = :userId OR f.user_b_id = :userId", nativeQuery = true)
+    List<Long> findFriendIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/gbsw/snapy/domain/stories/controller/StoryController.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/controller/StoryController.java
@@ -1,0 +1,38 @@
+package com.gbsw.snapy.domain.stories.controller;
+
+import com.gbsw.snapy.domain.stories.dto.response.StoryDetailResponse;
+import com.gbsw.snapy.domain.stories.dto.response.StoryListResponse;
+import com.gbsw.snapy.domain.stories.service.StoryService;
+import com.gbsw.snapy.global.common.ApiResponse;
+import com.gbsw.snapy.global.security.CustomUserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stories")
+public class StoryController {
+
+    private final StoryService storyService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<StoryListResponse>>> getStories(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        List<StoryListResponse> response = storyService.getStories(principal.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{storyId}")
+    public ResponseEntity<ApiResponse<StoryDetailResponse>> getStoryDetail(
+            @PathVariable Long storyId,
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        StoryDetailResponse response = storyService.getStoryDetail(storyId, principal.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/stories/dto/response/StoryDetailResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/dto/response/StoryDetailResponse.java
@@ -1,0 +1,24 @@
+package com.gbsw.snapy.domain.stories.dto.response;
+
+import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record StoryDetailResponse(
+        Long storyId,
+        String handle,
+        String username,
+        String profileImageUrl,
+        List<StoryPhotoSet> photos,
+        LocalDateTime createdAt,
+        LocalDateTime expiresAt
+) {
+    public record StoryPhotoSet(
+            AlbumPhotoType type,
+            String frontImageUrl,
+            String backImageUrl,
+            LocalDateTime createdAt
+    ) {
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/stories/dto/response/StoryListResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/dto/response/StoryListResponse.java
@@ -1,0 +1,14 @@
+package com.gbsw.snapy.domain.stories.dto.response;
+
+import java.time.LocalDateTime;
+
+public record StoryListResponse(
+        Long storyId,
+        String handle,
+        String username,
+        String profileImageUrl,
+        String thumbnailUrl,
+        LocalDateTime createdAt,
+        LocalDateTime expiresAt
+) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/stories/entity/Story.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/entity/Story.java
@@ -25,11 +25,6 @@ public class Story {
     @Column(name = "album_id", nullable = false)
     private Long albumId;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    @Builder.Default
-    private StoryStatus status = StoryStatus.ACTIVE;
-
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -41,11 +36,7 @@ public class Story {
         this.createdAt = LocalDateTime.now();
     }
 
-    public void expire() {
-        this.status = StoryStatus.EXPIRED;
-    }
-
-    public boolean isExpired() {
-        return this.status == StoryStatus.EXPIRED;
+    public boolean isExpired(LocalDateTime now) {
+        return this.expiresAt.isBefore(now);
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/stories/entity/StoryStatus.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/entity/StoryStatus.java
@@ -1,6 +1,0 @@
-package com.gbsw.snapy.domain.stories.entity;
-
-public enum StoryStatus {
-    ACTIVE,
-    EXPIRED
-}

--- a/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryPhotoRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryPhotoRepository.java
@@ -3,5 +3,11 @@ package com.gbsw.snapy.domain.stories.repository;
 import com.gbsw.snapy.domain.stories.entity.StoryPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StoryPhotoRepository extends JpaRepository<StoryPhoto, Long> {
+
+    List<StoryPhoto> findByStoryIdOrderByTypeAsc(Long storyId);
+
+    List<StoryPhoto> findByStoryIdInOrderByTypeAsc(List<Long> storyIds);
 }

--- a/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryRepository.java
@@ -1,11 +1,17 @@
 package com.gbsw.snapy.domain.stories.repository;
 
 import com.gbsw.snapy.domain.stories.entity.Story;
+import com.gbsw.snapy.domain.stories.entity.StoryStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface StoryRepository extends JpaRepository<Story, Long> {
 
     Optional<Story> findByUserIdAndAlbumId(Long userId, Long albumId);
+
+    List<Story> findByUserIdInAndStatusAndExpiresAtAfterOrderByCreatedAtDesc(
+            List<Long> userIds, StoryStatus status, LocalDateTime now);
 }

--- a/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryRepository.java
@@ -1,7 +1,6 @@
 package com.gbsw.snapy.domain.stories.repository;
 
 import com.gbsw.snapy.domain.stories.entity.Story;
-import com.gbsw.snapy.domain.stories.entity.StoryStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
@@ -12,6 +11,6 @@ public interface StoryRepository extends JpaRepository<Story, Long> {
 
     Optional<Story> findByUserIdAndAlbumId(Long userId, Long albumId);
 
-    List<Story> findByUserIdInAndStatusAndExpiresAtAfterOrderByCreatedAtDesc(
-            List<Long> userIds, StoryStatus status, LocalDateTime now);
+    List<Story> findByUserIdInAndExpiresAtAfterOrderByCreatedAtDesc(
+            List<Long> userIds, LocalDateTime now);
 }

--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -1,11 +1,24 @@
 package com.gbsw.snapy.domain.stories.service;
 
 import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
+import com.gbsw.snapy.domain.friends.repository.FriendRepository;
+import com.gbsw.snapy.domain.photos.entity.Photo;
 import com.gbsw.snapy.domain.photos.entity.PhotoType;
+import com.gbsw.snapy.domain.photos.repository.PhotoRepository;
+import com.gbsw.snapy.domain.settings.entity.UserSetting;
+import com.gbsw.snapy.domain.settings.entity.Visibility;
+import com.gbsw.snapy.domain.settings.repository.UserSettingRepository;
+import com.gbsw.snapy.domain.stories.dto.response.StoryDetailResponse;
+import com.gbsw.snapy.domain.stories.dto.response.StoryListResponse;
 import com.gbsw.snapy.domain.stories.entity.Story;
 import com.gbsw.snapy.domain.stories.entity.StoryPhoto;
+import com.gbsw.snapy.domain.stories.entity.StoryStatus;
 import com.gbsw.snapy.domain.stories.repository.StoryPhotoRepository;
 import com.gbsw.snapy.domain.stories.repository.StoryRepository;
+import com.gbsw.snapy.domain.users.entity.User;
+import com.gbsw.snapy.domain.users.repository.UserRepository;
+import com.gbsw.snapy.global.exception.CustomException;
+import com.gbsw.snapy.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -13,6 +26,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +38,10 @@ public class StoryService {
 
     private final StoryRepository storyRepository;
     private final StoryPhotoRepository storyPhotoRepository;
+    private final FriendRepository friendRepository;
+    private final UserRepository userRepository;
+    private final PhotoRepository photoRepository;
+    private final UserSettingRepository userSettingRepository;
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -54,6 +76,146 @@ public class StoryService {
                         .type(type)
                         .side(PhotoType.BACK)
                         .build()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<StoryListResponse> getStories(Long userId) {
+        List<Long> friendIds = friendRepository.findFriendIdsByUserId(userId);
+        if (friendIds.isEmpty()) {
+            return List.of();
+        }
+
+        LocalDateTime nowKst = LocalDateTime.now(KST_ZONE);
+        List<Story> stories = storyRepository
+                .findByUserIdInAndStatusAndExpiresAtAfterOrderByCreatedAtDesc(
+                        friendIds, StoryStatus.ACTIVE, nowKst);
+
+        if (stories.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> storyUserIds = stories.stream().map(Story::getUserId).distinct().toList();
+        Map<Long, User> userMap = userRepository.findAllById(storyUserIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        List<Long> storyIds = stories.stream().map(Story::getId).toList();
+        List<StoryPhoto> allPhotos = storyPhotoRepository.findByStoryIdInOrderByTypeAsc(storyIds);
+
+        Map<Long, List<StoryPhoto>> photosByStoryId = allPhotos.stream()
+                .collect(Collectors.groupingBy(StoryPhoto::getStoryId));
+
+        Map<Long, Photo> photoMap = photoRepository.findAllById(
+                allPhotos.stream()
+                        .filter(sp -> sp.getSide() == PhotoType.FRONT)
+                        .map(StoryPhoto::getPhotoId)
+                        .toList()
+        ).stream().collect(Collectors.toMap(Photo::getId, Function.identity()));
+
+        List<StoryListResponse> result = new ArrayList<>();
+        for (Story story : stories) {
+            User user = userMap.get(story.getUserId());
+            if (user == null) continue;
+
+            List<StoryPhoto> storyPhotos = photosByStoryId.getOrDefault(story.getId(), List.of());
+            StoryPhoto firstFront = storyPhotos.stream()
+                    .filter(sp -> sp.getSide() == PhotoType.FRONT)
+                    .findFirst()
+                    .orElse(null);
+
+            String thumbnailUrl = null;
+            if (firstFront != null) {
+                Photo photo = photoMap.get(firstFront.getPhotoId());
+                if (photo != null) {
+                    thumbnailUrl = photo.getImageUrl();
+                }
+            }
+
+            result.add(new StoryListResponse(
+                    story.getId(),
+                    user.getHandle(),
+                    user.getUsername(),
+                    user.getProfileImageUrl(),
+                    thumbnailUrl,
+                    story.getCreatedAt(),
+                    story.getExpiresAt()
+            ));
+        }
+
+        return result;
+    }
+
+    @Transactional
+    public StoryDetailResponse getStoryDetail(Long storyId, Long userId) {
+        Story story = storyRepository.findById(storyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORY_NOT_FOUND));
+
+        LocalDateTime nowKst = LocalDateTime.now(KST_ZONE);
+        if (story.getExpiresAt().isBefore(nowKst) && !story.isExpired()) {
+            story.expire();
+        }
+        if (story.isExpired()) {
+            throw new CustomException(ErrorCode.STORY_EXPIRED);
+        }
+
+        Long ownerId = story.getUserId();
+        if (!ownerId.equals(userId)) {
+            Visibility feedVisibility = userSettingRepository.findById(ownerId)
+                    .map(UserSetting::getFeedVisibility)
+                    .orElse(Visibility.FRIENDS_ONLY);
+
+            if (feedVisibility == Visibility.FRIENDS_ONLY) {
+                boolean isFriend = friendRepository.existsFriendship(userId, ownerId);
+                if (!isFriend) {
+                    throw new CustomException(ErrorCode.ACCESS_DENIED);
+                }
+            }
+        }
+
+        User owner = userRepository.findById(ownerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<StoryPhoto> storyPhotos = storyPhotoRepository.findByStoryIdOrderByTypeAsc(storyId);
+
+        List<Long> photoIds = storyPhotos.stream().map(StoryPhoto::getPhotoId).toList();
+        Map<Long, Photo> photoMap = photoRepository.findAllById(photoIds).stream()
+                .collect(Collectors.toMap(Photo::getId, Function.identity()));
+
+        Map<AlbumPhotoType, List<StoryPhoto>> groupedByType = storyPhotos.stream()
+                .collect(Collectors.groupingBy(StoryPhoto::getType));
+
+        List<StoryDetailResponse.StoryPhotoSet> photoSets = new ArrayList<>();
+        for (Map.Entry<AlbumPhotoType, List<StoryPhoto>> entry : groupedByType.entrySet()) {
+            String frontUrl = null;
+            String backUrl = null;
+            LocalDateTime photoCreatedAt = null;
+
+            for (StoryPhoto sp : entry.getValue()) {
+                Photo photo = photoMap.get(sp.getPhotoId());
+                if (photo == null) continue;
+
+                if (sp.getSide() == PhotoType.FRONT) {
+                    frontUrl = photo.getImageUrl();
+                    photoCreatedAt = sp.getCreatedAt();
+                } else {
+                    backUrl = photo.getImageUrl();
+                }
+            }
+
+            photoSets.add(new StoryDetailResponse.StoryPhotoSet(
+                    entry.getKey(), frontUrl, backUrl, photoCreatedAt));
+        }
+
+        photoSets.sort((a, b) -> a.type().compareTo(b.type()));
+
+        return new StoryDetailResponse(
+                story.getId(),
+                owner.getHandle(),
+                owner.getUsername(),
+                owner.getProfileImageUrl(),
+                photoSets,
+                story.getCreatedAt(),
+                story.getExpiresAt()
         );
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -94,6 +94,18 @@ public class StoryService {
         }
 
         List<Long> storyUserIds = stories.stream().map(Story::getUserId).distinct().toList();
+
+        Map<Long, Visibility> visibilityMap = userSettingRepository.findAllById(storyUserIds).stream()
+                .collect(Collectors.toMap(UserSetting::getUserId, UserSetting::getFeedVisibility));
+
+        stories = stories.stream()
+                .filter(story -> visibilityMap.getOrDefault(story.getUserId(), Visibility.FRIENDS_ONLY) != Visibility.ONLY_ME)
+                .toList();
+
+        if (stories.isEmpty()) {
+            return List.of();
+        }
+
         Map<Long, User> userMap = userRepository.findAllById(storyUserIds).stream()
                 .collect(Collectors.toMap(User::getId, Function.identity()));
 
@@ -158,6 +170,10 @@ public class StoryService {
             Visibility feedVisibility = userSettingRepository.findById(ownerId)
                     .map(UserSetting::getFeedVisibility)
                     .orElse(Visibility.FRIENDS_ONLY);
+
+            if (feedVisibility == Visibility.ONLY_ME) {
+                throw new CustomException(ErrorCode.ACCESS_DENIED);
+            }
 
             if (feedVisibility == Visibility.FRIENDS_ONLY) {
                 boolean isFriend = friendRepository.existsFriendship(userId, ownerId);

--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -12,7 +12,6 @@ import com.gbsw.snapy.domain.stories.dto.response.StoryDetailResponse;
 import com.gbsw.snapy.domain.stories.dto.response.StoryListResponse;
 import com.gbsw.snapy.domain.stories.entity.Story;
 import com.gbsw.snapy.domain.stories.entity.StoryPhoto;
-import com.gbsw.snapy.domain.stories.entity.StoryStatus;
 import com.gbsw.snapy.domain.stories.repository.StoryPhotoRepository;
 import com.gbsw.snapy.domain.stories.repository.StoryRepository;
 import com.gbsw.snapy.domain.users.entity.User;
@@ -88,8 +87,7 @@ public class StoryService {
 
         LocalDateTime nowKst = LocalDateTime.now(KST_ZONE);
         List<Story> stories = storyRepository
-                .findByUserIdInAndStatusAndExpiresAtAfterOrderByCreatedAtDesc(
-                        friendIds, StoryStatus.ACTIVE, nowKst);
+                .findByUserIdInAndExpiresAtAfterOrderByCreatedAtDesc(friendIds, nowKst);
 
         if (stories.isEmpty()) {
             return List.of();
@@ -145,16 +143,13 @@ public class StoryService {
         return result;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public StoryDetailResponse getStoryDetail(Long storyId, Long userId) {
         Story story = storyRepository.findById(storyId)
                 .orElseThrow(() -> new CustomException(ErrorCode.STORY_NOT_FOUND));
 
         LocalDateTime nowKst = LocalDateTime.now(KST_ZONE);
-        if (story.getExpiresAt().isBefore(nowKst) && !story.isExpired()) {
-            story.expire();
-        }
-        if (story.isExpired()) {
+        if (story.isExpired(nowKst)) {
             throw new CustomException(ErrorCode.STORY_EXPIRED);
         }
 


### PR DESCRIPTION
### Type of PR
feat
### Changes
- `GET /api/stories` 친구 스토리 목록 조회 (활성 & 미만료 스토리만 반환, 첫 FRONT 사진 썸네일 포함)
- `GET /api/stories/{storyId}` 스토리 상세 조회 (공개 설정에 따른 접근 제어)
- FriendRepository에 친구 ID 목록 조회 쿼리 추가
### Additional
- 스토리 목록은 친구의 스토리만 조회하므로 FRIENDS_ONLY 설정은 자동 충족되어 별도 필터링 불필요
- close #58 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 친구 기반 스토리 피드 조회 기능 추가
  * 스토리 상세 조회(사진 포함) 및 사진 묶음 표시 기능 추가
  * 스토리 썸네일 자동 생성 및 표시 기능 추가
  * 사용자 설정에 따른 스토리 공개 범위(전체/친구/비공개) 적용
  * 스토리 만료 판정이 타임스탬프 기준으로 변경되어 실시간 만료 검사 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->