### PR TITLE
feat: 다른 사용자 월별 앨범 목록 조회 및 visibility 분기 적용

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/controller/AlbumController.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/controller/AlbumController.java
@@ -36,9 +36,11 @@ public class AlbumController {
     @GetMapping
     public ResponseEntity<ApiResponse<List<AlbumListResponse>>> getAlbumsByMonth(
             @RequestParam int month,
+            @RequestParam(required = false) Long userId,
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        List<AlbumListResponse> response = albumService.getAlbumsByMonth(principal.getId(), month);
+        Long targetUserId = (userId != null) ? userId : principal.getId();
+        List<AlbumListResponse> response = albumService.getAlbumsByMonth(targetUserId, month, principal.getId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -22,6 +22,10 @@ import com.gbsw.snapy.global.exception.ErrorCode;
 import com.gbsw.snapy.domain.stories.entity.Story;
 import com.gbsw.snapy.domain.stories.repository.StoryRepository;
 import com.gbsw.snapy.domain.stories.service.StoryService;
+import com.gbsw.snapy.domain.friends.repository.FriendRepository;
+import com.gbsw.snapy.domain.settings.entity.UserSetting;
+import com.gbsw.snapy.domain.settings.entity.Visibility;
+import com.gbsw.snapy.domain.settings.repository.UserSettingRepository;
 import com.gbsw.snapy.infra.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -54,6 +58,8 @@ public class AlbumService {
     private final S3Service s3Service;
     private final StoryService storyService;
     private final StoryRepository storyRepository;
+    private final UserSettingRepository userSettingRepository;
+    private final FriendRepository friendRepository;
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
     @Transactional
@@ -203,18 +209,49 @@ public class AlbumService {
     }
 
     @Transactional(readOnly = true)
-    public List<AlbumListResponse> getAlbumsByMonth(Long userId, int month) {
+    public List<AlbumListResponse> getAlbumsByMonth(Long targetUserId, int month, Long requesterId) {
         if (month < 1 || month > 12) {
             throw new CustomException(ErrorCode.INVALID_MONTH);
         }
 
-        int year = ZonedDateTime.now(KST_ZONE).getYear();
+        boolean isOwner = targetUserId.equals(requesterId);
+        YearMonth currentMonth = YearMonth.now(KST_ZONE);
+        int year = currentMonth.getYear();
+        boolean isCurrentMonth = YearMonth.of(year, month).equals(currentMonth);
+
+        if (!isOwner) {
+            UserSetting setting = userSettingRepository.findById(targetUserId).orElse(null);
+
+            if (isCurrentMonth) {
+                Visibility feedVisibility = (setting != null) ? setting.getFeedVisibility() : Visibility.FRIENDS_ONLY;
+                if (feedVisibility == Visibility.FRIENDS_ONLY) {
+                    if (!friendRepository.existsFriendship(requesterId, targetUserId)) {
+                        throw new CustomException(ErrorCode.ACCESS_DENIED);
+                    }
+                }
+            } else {
+                Visibility albumVisibility = (setting != null) ? setting.getAlbumVisibility() : Visibility.FRIENDS_ONLY;
+                if (albumVisibility == Visibility.ONLY_ME) {
+                    throw new CustomException(ErrorCode.ACCESS_DENIED);
+                }
+                if (albumVisibility == Visibility.FRIENDS_ONLY) {
+                    if (!friendRepository.existsFriendship(requesterId, targetUserId)) {
+                        throw new CustomException(ErrorCode.ACCESS_DENIED);
+                    }
+                }
+            }
+        }
         YearMonth yearMonth = YearMonth.of(year, month);
         LocalDate start = yearMonth.atDay(1);
         LocalDate end = yearMonth.atEndOfMonth();
 
         List<DailyAlbum> albums = dailyAlbumRepository
-                .findByUserIdAndAlbumDateBetweenOrderByAlbumDateDesc(userId, start, end);
+                .findByUserIdAndAlbumDateBetweenOrderByAlbumDateDesc(targetUserId, start, end);
+        if (!isOwner) {
+            albums = albums.stream()
+                    .filter(a -> a.getStatus() == AlbumStatus.PUBLISHED)
+                    .toList();
+        }
         if (albums.isEmpty()) {
             return List.of();
         }


### PR DESCRIPTION
### Type of PR
feat
### Changes
- GET /api/albums에 userId 쿼리 파라미터 추가 (미전달 시 본인 조회)
- 이번 달 조회 시 feedVisibility 기준 접근 제어 적용
- 과거 달 조회 시 albumVisibility 기준 접근 제어 적용 (ONLY_ME 포함)
- 타인 앨범은 PUBLISHED 상태만 반환
### Additional
- feedVisibility는 이번 달 피드 + 스토리 공개 범위, albumVisibility는 과거 앨범 공개 범위
- close #63 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 다른 사용자의 앨범 조회 기능 추가: 사용자의 개인정보 설정과 친구 관계에 따라 앨범 접근 여부가 결정됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->