### PR TITLE
feat: 앨범 상세 조회에 visibility 접근 제어 추가

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -155,8 +155,31 @@ public class AlbumService {
         DailyAlbum album = dailyAlbumRepository.findById(albumId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
 
-        if (!album.getUserId().equals(userId) && album.getStatus() != AlbumStatus.PUBLISHED) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        if (!album.getUserId().equals(userId)) {
+            if (album.getStatus() != AlbumStatus.PUBLISHED) {
+                throw new CustomException(ErrorCode.ACCESS_DENIED);
+            }
+
+            YearMonth albumMonth = YearMonth.from(album.getAlbumDate());
+            YearMonth currentMonth = YearMonth.now(KST_ZONE);
+            boolean isCurrentMonth = albumMonth.equals(currentMonth);
+
+            UserSetting setting = userSettingRepository.findById(album.getUserId()).orElse(null);
+
+            if (isCurrentMonth) {
+                Visibility v = (setting != null) ? setting.getFeedVisibility() : Visibility.FRIENDS_ONLY;
+                if (v == Visibility.FRIENDS_ONLY && !friendRepository.existsFriendship(userId, album.getUserId())) {
+                    throw new CustomException(ErrorCode.ACCESS_DENIED);
+                }
+            } else {
+                Visibility v = (setting != null) ? setting.getAlbumVisibility() : Visibility.FRIENDS_ONLY;
+                if (v == Visibility.ONLY_ME) {
+                    throw new CustomException(ErrorCode.ACCESS_DENIED);
+                }
+                if (v == Visibility.FRIENDS_ONLY && !friendRepository.existsFriendship(userId, album.getUserId())) {
+                    throw new CustomException(ErrorCode.ACCESS_DENIED);
+                }
+            }
         }
 
         List<PhotoSetView> sets = loadPhotoSets(album.getId());


### PR DESCRIPTION
### Type of PR
feat
### Changes
- getAlbumDetail()에 앨범 날짜 기준 visibility 접근 제어 추가
- 이번 달 앨범: feedVisibility 기준 (PUBLIC / FRIENDS_ONLY)
- 과거 달 앨범: albumVisibility 기준 (PUBLIC / FRIENDS_ONLY / ONLY_ME)
- 기존 PUBLISHED 상태 검사는 유지
### Additional
- 기존에는 albumId만 알면 타인의 PUBLISHED 앨범을 공개 설정과 무관하게 상세 조회 가능했음
- close #65 