### PR TITLE
refactor: albumVisibility를 pastAlbumVisibility로 rename

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -172,7 +172,7 @@ public class AlbumService {
                     throw new CustomException(ErrorCode.ACCESS_DENIED);
                 }
             } else {
-                Visibility v = (setting != null) ? setting.getAlbumVisibility() : Visibility.FRIENDS_ONLY;
+                Visibility v = (setting != null) ? setting.getPastAlbumVisibility() : Visibility.FRIENDS_ONLY;
                 if (v == Visibility.ONLY_ME) {
                     throw new CustomException(ErrorCode.ACCESS_DENIED);
                 }
@@ -253,7 +253,7 @@ public class AlbumService {
                     }
                 }
             } else {
-                Visibility albumVisibility = (setting != null) ? setting.getAlbumVisibility() : Visibility.FRIENDS_ONLY;
+                Visibility albumVisibility = (setting != null) ? setting.getPastAlbumVisibility() : Visibility.FRIENDS_ONLY;
                 if (albumVisibility == Visibility.ONLY_ME) {
                     throw new CustomException(ErrorCode.ACCESS_DENIED);
                 }

--- a/src/main/java/com/gbsw/snapy/domain/settings/controller/UserSettingController.java
+++ b/src/main/java/com/gbsw/snapy/domain/settings/controller/UserSettingController.java
@@ -1,6 +1,6 @@
 package com.gbsw.snapy.domain.settings.controller;
 
-import com.gbsw.snapy.domain.settings.dto.request.UpdateAlbumVisibilityRequest;
+import com.gbsw.snapy.domain.settings.dto.request.UpdatePastAlbumVisibilityRequest;
 import com.gbsw.snapy.domain.settings.dto.request.UpdateFeedVisibilityRequest;
 import com.gbsw.snapy.domain.settings.dto.response.UserSettingResponse;
 import com.gbsw.snapy.domain.settings.service.UserSettingService;
@@ -35,12 +35,12 @@ public class UserSettingController {
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
-    @PatchMapping("/album-visibility")
-    public ResponseEntity<ApiResponse<Void>> updateAlbumVisibility(
-            @Valid @RequestBody UpdateAlbumVisibilityRequest request,
+    @PatchMapping("/past-album-visibility")
+    public ResponseEntity<ApiResponse<Void>> updatePastAlbumVisibility(
+            @Valid @RequestBody UpdatePastAlbumVisibilityRequest request,
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        userSettingService.updateAlbumVisibility(principal.getId(), request);
+        userSettingService.updatePastAlbumVisibility(principal.getId(), request);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/settings/dto/request/UpdatePastAlbumVisibilityRequest.java
+++ b/src/main/java/com/gbsw/snapy/domain/settings/dto/request/UpdatePastAlbumVisibilityRequest.java
@@ -3,7 +3,7 @@ package com.gbsw.snapy.domain.settings.dto.request;
 import com.gbsw.snapy.domain.settings.entity.Visibility;
 import jakarta.validation.constraints.NotNull;
 
-public record UpdateAlbumVisibilityRequest(
+public record UpdatePastAlbumVisibilityRequest(
         @NotNull(message = "visibility는 필수입니다. (PUBLIC, FRIENDS_ONLY, ONLY_ME)")
         Visibility visibility
 ) {

--- a/src/main/java/com/gbsw/snapy/domain/settings/dto/response/UserSettingResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/settings/dto/response/UserSettingResponse.java
@@ -5,9 +5,9 @@ import com.gbsw.snapy.domain.settings.entity.Visibility;
 
 public record UserSettingResponse(
         Visibility feedVisibility,
-        Visibility albumVisibility
+        Visibility pastAlbumVisibility
 ) {
     public static UserSettingResponse from(UserSetting setting) {
-        return new UserSettingResponse(setting.getFeedVisibility(), setting.getAlbumVisibility());
+        return new UserSettingResponse(setting.getFeedVisibility(), setting.getPastAlbumVisibility());
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/settings/entity/UserSetting.java
+++ b/src/main/java/com/gbsw/snapy/domain/settings/entity/UserSetting.java
@@ -18,13 +18,13 @@ public class UserSetting {
     private Visibility feedVisibility;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "album_visibility", nullable = false)
-    private Visibility albumVisibility;
+    @Column(name = "past_album_visibility", nullable = false)
+    private Visibility pastAlbumVisibility;
 
     @Builder
     public UserSetting(Long userId) {
         this.userId = userId;
         this.feedVisibility = Visibility.FRIENDS_ONLY;
-        this.albumVisibility = Visibility.FRIENDS_ONLY;
+        this.pastAlbumVisibility = Visibility.FRIENDS_ONLY;
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/settings/service/UserSettingService.java
+++ b/src/main/java/com/gbsw/snapy/domain/settings/service/UserSettingService.java
@@ -1,6 +1,6 @@
 package com.gbsw.snapy.domain.settings.service;
 
-import com.gbsw.snapy.domain.settings.dto.request.UpdateAlbumVisibilityRequest;
+import com.gbsw.snapy.domain.settings.dto.request.UpdatePastAlbumVisibilityRequest;
 import com.gbsw.snapy.domain.settings.dto.request.UpdateFeedVisibilityRequest;
 import com.gbsw.snapy.domain.settings.dto.response.UserSettingResponse;
 import com.gbsw.snapy.domain.settings.entity.UserSetting;
@@ -38,12 +38,12 @@ public class UserSettingService {
     }
 
     @Transactional
-    public void updateAlbumVisibility(Long userId, UpdateAlbumVisibilityRequest request) {
+    public void updatePastAlbumVisibility(Long userId, UpdatePastAlbumVisibilityRequest request) {
         if (request.visibility() == null) {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "visibility는 필수입니다. (PUBLIC, FRIENDS_ONLY, ONLY_ME)");
         }
         UserSetting setting = getOrCreate(userId);
-        setting.setAlbumVisibility(request.visibility());
+        setting.setPastAlbumVisibility(request.visibility());
     }
 
     private UserSetting getOrCreate(Long userId) {


### PR DESCRIPTION
### Type of PR
refactor
### Changes
- albumVisibility → pastAlbumVisibility로 필드/메서드/DTO/엔드포인트 전체 rename
- DB 컬럼명 album_visibility → past_album_visibility 변경
- API 엔드포인트 PATCH /api/users/me/settings/album-visibility → /past-album-visibility
### Additional
- albumVisibility는 실제로 과거 앨범 공개 범위 설정이므로 의미에 맞게 이름 변경
- close #67 