### PR TITLE
feat: S3 오디오 업로드 기능 추가 및 네이밍 리팩토링

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/audios/dto/response/AudioUploadResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/audios/dto/response/AudioUploadResponse.java
@@ -1,0 +1,21 @@
+package com.gbsw.snapy.domain.audios.dto.response;
+
+import com.gbsw.snapy.domain.audios.entity.Audio;
+
+import java.time.LocalDateTime;
+
+public record AudioUploadResponse(
+        Long audioId,
+        String s3Key,
+        String audioUrl,
+        LocalDateTime createdAt
+) {
+    public static AudioUploadResponse from(Audio audio) {
+        return new AudioUploadResponse(
+                audio.getId(),
+                audio.getS3Key(),
+                audio.getAudioUrl(),
+                audio.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/audios/entity/Audio.java
+++ b/src/main/java/com/gbsw/snapy/domain/audios/entity/Audio.java
@@ -1,0 +1,43 @@
+package com.gbsw.snapy.domain.audios.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name="audios")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Audio {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "s3_key", nullable = false)
+    private String s3Key;
+
+    @Column(name = "audio_url", nullable = false)
+    private String audioUrl;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public Audio(Long userId, String s3Key, String audioUrl) {
+        this.userId = userId;
+        this.s3Key = s3Key;
+        this.audioUrl = audioUrl;
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/audios/repository/AudioRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/audios/repository/AudioRepository.java
@@ -1,0 +1,7 @@
+package com.gbsw.snapy.domain.audios.repository;
+
+import com.gbsw.snapy.domain.audios.entity.Audio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AudioRepository extends JpaRepository<Audio, Long> {
+}

--- a/src/main/java/com/gbsw/snapy/domain/audios/service/AudioService.java
+++ b/src/main/java/com/gbsw/snapy/domain/audios/service/AudioService.java
@@ -1,0 +1,56 @@
+package com.gbsw.snapy.domain.audios.service;
+
+import com.gbsw.snapy.domain.audios.dto.response.AudioUploadResponse;
+import com.gbsw.snapy.domain.audios.entity.Audio;
+import com.gbsw.snapy.domain.audios.repository.AudioRepository;
+import com.gbsw.snapy.global.exception.CustomException;
+import com.gbsw.snapy.global.exception.ErrorCode;
+import com.gbsw.snapy.infra.s3.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AudioService {
+    private final S3Service s3Service;
+    private final AudioRepository audioRepository;
+
+    @Transactional
+    public AudioUploadResponse upload(MultipartFile file, Long userId) {
+        S3Service.S3UploadResult result = s3Service.uploadAudio(file, userId);
+
+        try {
+            Audio audio = Audio.builder()
+                    .userId(userId)
+                    .s3Key(result.s3Key())
+                    .audioUrl(result.fileUrl())
+                    .build();
+
+            Audio saved = audioRepository.save(audio);
+
+            return AudioUploadResponse.from(saved);
+        } catch (Exception e) {
+            s3Service.delete(result.s3Key());
+            throw e;
+        }
+    }
+
+    @Transactional
+    public void delete(Long audioId, Long userId) {
+        Audio audio = audioRepository.findById(audioId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUDIO_NOT_FOUND));
+
+        if (!audio.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        String s3Key = audio.getS3Key();
+        audioRepository.delete(audio);
+        audioRepository.flush();
+        s3Service.delete(s3Key);
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/photos/service/PhotoService.java
+++ b/src/main/java/com/gbsw/snapy/domain/photos/service/PhotoService.java
@@ -22,13 +22,13 @@ public class PhotoService {
 
     @Transactional
     public PhotoUploadResponse upload(MultipartFile file, Long userId, PhotoType type) {
-        S3Service.S3UploadResult result = s3Service.upload(file, userId);
+        S3Service.S3UploadResult result = s3Service.uploadImage(file, userId);
 
         try {
             Photo photo = Photo.builder()
                     .userId(userId)
                     .s3Key(result.s3Key())
-                    .imageUrl(result.imageUrl())
+                    .imageUrl(result.fileUrl())
                     .type(type)
                     .build();
 

--- a/src/main/java/com/gbsw/snapy/domain/users/service/UserService.java
+++ b/src/main/java/com/gbsw/snapy/domain/users/service/UserService.java
@@ -48,10 +48,10 @@ public class UserService {
 
         String oldKey = user.getBackGroundImageKey();
 
-        S3Service.S3UploadResult result = s3Service.upload(file, userId);
+        S3Service.S3UploadResult result = s3Service.uploadImage(file, userId);
 
         try {
-            user.setBackGroundImageUrl(result.imageUrl());
+            user.setBackGroundImageUrl(result.fileUrl());
             user.setBackGroundImageKey(result.s3Key());
         } catch (Exception e) {
             s3Service.delete(result.s3Key());
@@ -74,10 +74,10 @@ public class UserService {
 
         String oldKey = user.getProfileImageKey();
 
-        S3Service.S3UploadResult result = s3Service.upload(file, userId);
+        S3Service.S3UploadResult result = s3Service.uploadImage(file, userId);
 
         try {
-            user.setProfileImageUrl(result.imageUrl());
+            user.setProfileImageUrl(result.fileUrl());
             user.setProfileImageKey(result.s3Key());
         } catch (Exception e) {
             s3Service.delete(result.s3Key());

--- a/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
+++ b/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
@@ -29,13 +29,22 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     DUPLICATE_PHONE(HttpStatus.CONFLICT, "이미 사용 중인 전화번호입니다."),
 
+    // S3 general
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다."),
+
     // Image
     IMAGE_EMPTY(HttpStatus.BAD_REQUEST, "이미지가 비어있습니다."),
     INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
     IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 크기가 10MB를 초과합니다."),
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
-    IMAGE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제에 실패했습니다."),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),
+
+    // Audio
+    AUDIO_EMPTY(HttpStatus.BAD_REQUEST, "오디오 파일이 비어있습니다."),
+    INVALID_AUDIO_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 오디오 파일 형식입니다. (.m4a만 허용)"),
+    AUDIO_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "오디오 파일 크기가 20MB를 초과합니다."),
+    AUDIO_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "오디오 업로드에 실패했습니다."),
+    AUDIO_NOT_FOUND(HttpStatus.NOT_FOUND, "오디오를 찾을 수 없습니다."),
 
     // Album
     ALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "앨범을 찾을 수 없습니다."),

--- a/src/main/java/com/gbsw/snapy/infra/s3/S3Service.java
+++ b/src/main/java/com/gbsw/snapy/infra/s3/S3Service.java
@@ -30,14 +30,14 @@ public class S3Service {
             "image/webp", "webp"
     );
 
-    public S3UploadResult upload(MultipartFile file, Long userId) {
+    public S3UploadResult uploadImage(MultipartFile file, Long userId) {
         validateImageFile(file);
 
         if (userId == null) {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        String s3Key = generateS3Key(userId, file.getContentType());
+        String s3Key = generateImageS3Key(userId, file.getContentType());
 
         try (InputStream inputStream = file.getInputStream()) {
             s3Uploader.upload(s3Key, inputStream, file.getContentType(), file.getSize());
@@ -46,10 +46,32 @@ public class S3Service {
             throw new CustomException(ErrorCode.IMAGE_UPLOAD_FAILED);
         }
 
-        String imageUrl = cloudfrontDomain + "/" + s3Key;
-        log.info("S3업로드 완료 - key: {}", imageUrl);
+        String fileUrl = cloudfrontDomain + "/" + s3Key;
+        log.info("S3업로드 완료 - key: {}", fileUrl);
 
-        return new S3UploadResult(s3Key, imageUrl);
+        return new S3UploadResult(s3Key, fileUrl);
+    }
+
+    public S3UploadResult uploadAudio(MultipartFile file, Long userId) {
+        validateAudioFile(file);
+
+        if (userId == null) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        String s3Key = generateAudioS3Key(userId);
+
+        try (InputStream inputStream = file.getInputStream()) {
+            s3Uploader.upload(s3Key, inputStream, "audio/mp4", file.getSize());
+        } catch (Exception e) {
+            log.error("S3 업로드 실패 - key: {}, cause: {}", s3Key, e.getMessage(), e);
+            throw new CustomException(ErrorCode.AUDIO_UPLOAD_FAILED);
+        }
+
+        String fileUrl = cloudfrontDomain + "/" + s3Key;
+        log.info("S3업로드 완료 - key: {}", fileUrl);
+
+        return new S3UploadResult(s3Key, fileUrl);
     }
 
     public void delete(String s3Key) {
@@ -57,16 +79,39 @@ public class S3Service {
             s3Uploader.delete(s3Key);
             log.info("S3 삭제 완료 - key: {}", s3Key);
         } catch (Exception e) {
-            throw new CustomException(ErrorCode.IMAGE_DELETE_FAILED);
+            throw new CustomException(ErrorCode.FILE_DELETE_FAILED);
         }
     }
 
-    private String generateS3Key(Long userId, String contentType) {
+    private String generateImageS3Key(Long userId, String contentType) {
         String date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         String uuid = UUID.randomUUID().toString();
         String extension = CONTENT_TYPE_TO_EXTENSION.getOrDefault(contentType, "jpg");
 
         return String.format("photos/%s/%s/%s.%s", userId, date, uuid, extension);
+    }
+
+    private String generateAudioS3Key(Long userId) {
+        String date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        String uuid = UUID.randomUUID().toString();
+
+        return String.format("audios/%s/%s/%s.m4a", userId, date, uuid);
+    }
+
+    private void validateAudioFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new CustomException(ErrorCode.AUDIO_EMPTY);
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !originalFilename.toLowerCase().endsWith(".m4a")) {
+            throw new CustomException(ErrorCode.INVALID_AUDIO_TYPE);
+        }
+
+        long MAX_SIZE = 20 * 1024 * 1024L;
+        if (file.getSize() > MAX_SIZE) {
+            throw new CustomException(ErrorCode.AUDIO_SIZE_EXCEEDED);
+        }
     }
 
     private void validateImageFile(MultipartFile file) {
@@ -85,5 +130,5 @@ public class S3Service {
         }
     }
 
-    public record S3UploadResult(String s3Key, String imageUrl) {}
+    public record S3UploadResult(String s3Key, String fileUrl) {}
 }


### PR DESCRIPTION
### Type of PR
feat

### Changes
- AudioService, AudioUploadResponse 생성
- S3Service에 uploadAudio, validateAudioFile, generateAudioS3Key 추가
- upload → uploadImage, generateS3Key → generateImageS3Key로 분리
- S3UploadResult.imageUrl → fileUrl, IMAGE_DELETE_FAILED → FILE_DELETE_FAILED 범용화
- 오디오 관련 ErrorCode 추가 (AUDIO_EMPTY, INVALID_AUDIO_TYPE 등)

### Additional
- S3 경로: audios/{userId}/{date}/{uuid}.m4a
- 파일 제한: m4a / 최대 20MB

close #72 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 오디오 파일 업로드 및 삭제 기능 추가
  * 오디오 파일 형식 및 크기 검증 지원 (.m4a 형식, 최대 20MB)

* **개선 사항**
  * 이미지와 오디오 업로드에 대한 개별 최적화
  * 파일 작업 실패 시 개선된 오류 메시지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->