### PR TITLE
Feat/#40 댓글 기능 추가

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/comments/controller/CommentController.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/controller/CommentController.java
@@ -41,4 +41,13 @@ public class CommentController {
         CursorResponse<CommentResponse> response = commentService.getComments(albumId, cursor, size);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    @DeleteMapping("comments/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> delete(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        commentService.delete(commentId, principal.getId());
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
 }

--- a/src/main/java/com/gbsw/snapy/domain/comments/controller/CommentController.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/controller/CommentController.java
@@ -16,12 +16,12 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/albums/{albumId}/comments")
+@RequestMapping("/api")
 public class CommentController {
 
     private final CommentService commentService;
 
-    @PostMapping
+    @PostMapping("albums/{albumId}/comments")
     public ResponseEntity<ApiResponse<CommentUploadResponse>> upload(
             @PathVariable Long albumId,
             @Valid @ModelAttribute CommentUploadRequest request,
@@ -31,7 +31,7 @@ public class CommentController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 
-    @GetMapping
+    @GetMapping("albums/{albumId}/comments")
     public ResponseEntity<ApiResponse<CursorResponse<CommentResponse>>> getComments(
             @PathVariable Long albumId,
             @RequestParam(required = false) Long cursor,

--- a/src/main/java/com/gbsw/snapy/domain/comments/controller/CommentController.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/controller/CommentController.java
@@ -35,8 +35,7 @@ public class CommentController {
     public ResponseEntity<ApiResponse<CursorResponse<CommentResponse>>> getComments(
             @PathVariable Long albumId,
             @RequestParam(required = false) Long cursor,
-            @RequestParam(defaultValue = "20") int size,
-            @AuthenticationPrincipal CustomUserPrincipal principal
+            @RequestParam(defaultValue = "20") int size
     ) {
         CursorResponse<CommentResponse> response = commentService.getComments(albumId, cursor, size);
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/gbsw/snapy/domain/comments/controller/CommentController.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/controller/CommentController.java
@@ -1,9 +1,11 @@
 package com.gbsw.snapy.domain.comments.controller;
 
 import com.gbsw.snapy.domain.comments.dto.request.CommentUploadRequest;
+import com.gbsw.snapy.domain.comments.dto.response.CommentResponse;
 import com.gbsw.snapy.domain.comments.dto.response.CommentUploadResponse;
 import com.gbsw.snapy.domain.comments.service.CommentService;
 import com.gbsw.snapy.global.common.ApiResponse;
+import com.gbsw.snapy.global.common.CursorResponse;
 import com.gbsw.snapy.global.security.CustomUserPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,5 +29,16 @@ public class CommentController {
     ) {
         CommentUploadResponse response = commentService.upload(albumId, principal.getId(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<CursorResponse<CommentResponse>>> getComments(
+            @PathVariable Long albumId,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") int size,
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        CursorResponse<CommentResponse> response = commentService.getComments(albumId, cursor, size);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/comments/controller/CommentController.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/controller/CommentController.java
@@ -1,0 +1,31 @@
+package com.gbsw.snapy.domain.comments.controller;
+
+import com.gbsw.snapy.domain.comments.dto.request.CommentUploadRequest;
+import com.gbsw.snapy.domain.comments.dto.response.CommentUploadResponse;
+import com.gbsw.snapy.domain.comments.service.CommentService;
+import com.gbsw.snapy.global.common.ApiResponse;
+import com.gbsw.snapy.global.security.CustomUserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/albums/{albumId}/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CommentUploadResponse>> upload(
+            @PathVariable Long albumId,
+            @Valid @ModelAttribute CommentUploadRequest request,
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        CommentUploadResponse response = commentService.upload(albumId, principal.getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/comments/dto/request/CommentUploadRequest.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/dto/request/CommentUploadRequest.java
@@ -1,0 +1,21 @@
+package com.gbsw.snapy.domain.comments.dto.request;
+
+import com.gbsw.snapy.domain.comments.entity.AttachmentType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CommentUploadRequest {
+
+    @NotNull(message = "댓글 타입은 필수입니다.")
+    private AttachmentType type;
+
+    private String emojiValue;
+
+    private MultipartFile file;
+}

--- a/src/main/java/com/gbsw/snapy/domain/comments/dto/response/CommentResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/dto/response/CommentResponse.java
@@ -1,0 +1,47 @@
+package com.gbsw.snapy.domain.comments.dto.response;
+
+import com.gbsw.snapy.domain.comments.entity.AttachmentType;
+import com.gbsw.snapy.domain.comments.entity.Comment;
+import com.gbsw.snapy.domain.comments.entity.CommentAttachment;
+
+import java.time.LocalDateTime;
+
+public record CommentResponse(
+        Long commentId,
+        Long userId,
+        String handle,
+        String profileImageUrl,
+        AttachmentType type,
+        String emojiValue,
+        String imageUrl,
+        String audioUrl,
+        LocalDateTime createdAt
+) {
+    public static CommentResponse from(Comment comment) {
+        CommentAttachment attachment = comment.getAttachment();
+
+        AttachmentType type = null;
+        String emojiValue = null;
+        String imageUrl = null;
+        String audioUrl = null;
+
+        if (attachment != null) {
+            type = attachment.getType();
+            emojiValue = attachment.getEmojiValue();
+            imageUrl = attachment.getPhoto() != null ? attachment.getPhoto().getImageUrl() : null;
+            audioUrl = attachment.getAudio() != null ? attachment.getAudio().getAudioUrl() : null;
+        }
+
+        return new CommentResponse(
+                comment.getId(),
+                comment.getUser().getId(),
+                comment.getUser().getHandle(),
+                comment.getUser().getProfileImageUrl(),
+                type,
+                emojiValue,
+                imageUrl,
+                audioUrl,
+                comment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/comments/dto/response/CommentUploadResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/dto/response/CommentUploadResponse.java
@@ -1,0 +1,45 @@
+package com.gbsw.snapy.domain.comments.dto.response;
+
+import com.gbsw.snapy.domain.comments.entity.AttachmentType;
+import com.gbsw.snapy.domain.comments.entity.Comment;
+import com.gbsw.snapy.domain.comments.entity.CommentAttachment;
+
+import java.time.LocalDateTime;
+
+public record CommentUploadResponse(
+        Long commentId,
+        Long attachmentId,
+        AttachmentType type,
+        String emojiValue,
+        String imageUrl,
+        String audioUrl,
+        LocalDateTime createdAt
+) {
+    public static CommentUploadResponse from(Comment comment) {
+        CommentAttachment attachment = comment.getAttachment();
+
+        Long attachmentId = null;
+        AttachmentType type = null;
+        String emojiValue = null;
+        String imageUrl = null;
+        String audioUrl = null;
+
+        if (attachment != null) {
+            attachmentId = attachment.getId();
+            type = attachment.getType();
+            emojiValue = attachment.getEmojiValue();
+            imageUrl = attachment.getPhoto() != null ? attachment.getPhoto().getImageUrl() : null;
+            audioUrl = attachment.getAudio() != null ? attachment.getAudio().getAudioUrl() : null;
+        }
+
+        return new CommentUploadResponse(
+                comment.getId(),
+                attachmentId,
+                type,
+                emojiValue,
+                imageUrl,
+                audioUrl,
+                comment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/comments/entity/AttachmentType.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/entity/AttachmentType.java
@@ -1,0 +1,7 @@
+package com.gbsw.snapy.domain.comments.entity;
+
+public enum AttachmentType {
+    EMOJI,
+    IMAGE,
+    AUDIO
+}

--- a/src/main/java/com/gbsw/snapy/domain/comments/entity/Comment.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/entity/Comment.java
@@ -1,0 +1,49 @@
+package com.gbsw.snapy.domain.comments.entity;
+
+import com.gbsw.snapy.domain.albums.entity.DailyAlbum;
+import com.gbsw.snapy.domain.users.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "album_id", nullable = false)
+    private DailyAlbum album;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "attachment_id")
+    private CommentAttachment attachment;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public Comment(DailyAlbum album, User user, CommentAttachment attachment) {
+        this.album = album;
+        this.user = user;
+        this.attachment = attachment;
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/comments/entity/CommentAttachment.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/entity/CommentAttachment.java
@@ -1,0 +1,64 @@
+package com.gbsw.snapy.domain.comments.entity;
+
+import com.gbsw.snapy.domain.audios.entity.Audio;
+import com.gbsw.snapy.domain.photos.entity.Photo;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "comment_attachments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentAttachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AttachmentType type;
+
+    @Column(name = "emoji_value")
+    private String emojiValue;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "photo_id")
+    private Photo photo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "audio_id")
+    private Audio audio;
+
+    @Builder
+    public CommentAttachment(AttachmentType type, String emojiValue, Photo photo, Audio audio) {
+        this.type = type;
+        this.emojiValue = emojiValue;
+        this.photo = photo;
+        this.audio = audio;
+    }
+
+    public static CommentAttachment ofEmoji(String emojiValue) {
+        return CommentAttachment.builder()
+                .type(AttachmentType.EMOJI)
+                .emojiValue(emojiValue)
+                .build();
+    }
+
+    public static CommentAttachment ofImage(Photo photo) {
+        return CommentAttachment.builder()
+                .type(AttachmentType.IMAGE)
+                .photo(photo)
+                .build();
+    }
+
+    public static CommentAttachment ofAudio(Audio audio) {
+        return CommentAttachment.builder()
+                .type(AttachmentType.AUDIO)
+                .audio(audio)
+                .build();
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/comments/repository/CommentAttachmentRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/repository/CommentAttachmentRepository.java
@@ -1,0 +1,7 @@
+package com.gbsw.snapy.domain.comments.repository;
+
+import com.gbsw.snapy.domain.comments.entity.CommentAttachment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentAttachmentRepository extends JpaRepository<CommentAttachment, Long> {
+}

--- a/src/main/java/com/gbsw/snapy/domain/comments/repository/CommentRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.gbsw.snapy.domain.comments.repository;
+
+import com.gbsw.snapy.domain.comments.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/gbsw/snapy/domain/comments/repository/CommentRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/repository/CommentRepository.java
@@ -2,6 +2,37 @@ package com.gbsw.snapy.domain.comments.repository;
 
 import com.gbsw.snapy.domain.comments.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT c FROM Comment c " +
+            "JOIN FETCH c.user " +
+            "LEFT JOIN FETCH c.attachment a " +
+            "LEFT JOIN FETCH a.photo " +
+            "LEFT JOIN FETCH a.audio " +
+            "WHERE c.album.id = :albumId AND c.id < :cursor " +
+            "ORDER BY c.id DESC " +
+            "LIMIT :size")
+    List<Comment> findByAlbumIdWithCursor(
+            @Param("albumId") Long albumId,
+            @Param("cursor") Long cursor,
+            @Param("size") int size
+    );
+
+    @Query("SELECT c FROM Comment c " +
+            "JOIN FETCH c.user " +
+            "LEFT JOIN FETCH c.attachment a " +
+            "LEFT JOIN FETCH a.photo " +
+            "LEFT JOIN FETCH a.audio " +
+            "WHERE c.album.id = :albumId " +
+            "ORDER BY c.id DESC " +
+            "LIMIT :size")
+    List<Comment> findByAlbumIdLatest(
+            @Param("albumId") Long albumId,
+            @Param("size") int size
+    );
 }

--- a/src/main/java/com/gbsw/snapy/domain/comments/service/CommentService.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/service/CommentService.java
@@ -115,4 +115,33 @@ public class CommentService {
 
         return CursorResponse.of(content, nextCursor, hasNext);
     }
+
+    @Transactional
+    public void delete(Long commentId, Long userId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        CommentAttachment attachment = comment.getAttachment();
+        Long photoId = (attachment != null && attachment.getPhoto() != null) ? attachment.getPhoto().getId() : null;
+        Long audioId = (attachment != null && attachment.getAudio() != null) ? attachment.getAudio().getId() : null;
+
+        commentRepository.delete(comment);
+        commentRepository.flush();
+
+        if (attachment != null) {
+            commentAttachmentRepository.delete(attachment);
+            commentAttachmentRepository.flush();
+        }
+
+        if (photoId != null) {
+            photoService.delete(photoId, userId);
+        }
+        if (audioId != null) {
+            audioService.delete(audioId, userId);
+        }
+    }
 }

--- a/src/main/java/com/gbsw/snapy/domain/comments/service/CommentService.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/service/CommentService.java
@@ -7,7 +7,9 @@ import com.gbsw.snapy.domain.audios.entity.Audio;
 import com.gbsw.snapy.domain.audios.repository.AudioRepository;
 import com.gbsw.snapy.domain.audios.service.AudioService;
 import com.gbsw.snapy.domain.comments.dto.request.CommentUploadRequest;
+import com.gbsw.snapy.domain.comments.dto.response.CommentResponse;
 import com.gbsw.snapy.domain.comments.dto.response.CommentUploadResponse;
+import com.gbsw.snapy.global.common.CursorResponse;
 import com.gbsw.snapy.domain.comments.entity.Comment;
 import com.gbsw.snapy.domain.comments.entity.CommentAttachment;
 import com.gbsw.snapy.domain.comments.repository.CommentAttachmentRepository;
@@ -25,6 +27,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -86,5 +90,29 @@ public class CommentService {
         );
 
         return CommentUploadResponse.from(comment);
+    }
+
+    @Transactional(readOnly = true)
+    public CursorResponse<CommentResponse> getComments(Long albumId, Long cursor, int size) {
+        if (!dailyAlbumRepository.existsById(albumId)) {
+            throw new CustomException(ErrorCode.ALBUM_NOT_FOUND);
+        }
+
+        List<Comment> comments = (cursor == null)
+                ? commentRepository.findByAlbumIdLatest(albumId, size + 1)
+                : commentRepository.findByAlbumIdWithCursor(albumId, cursor, size + 1);
+
+        boolean hasNext = comments.size() > size;
+        if (hasNext) {
+            comments = comments.subList(0, size);
+        }
+
+        List<CommentResponse> content = comments.stream()
+                .map(CommentResponse::from)
+                .toList();
+
+        Long nextCursor = hasNext ? comments.get(comments.size() - 1).getId() : null;
+
+        return CursorResponse.of(content, nextCursor, hasNext);
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/comments/service/CommentService.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/service/CommentService.java
@@ -1,0 +1,90 @@
+package com.gbsw.snapy.domain.comments.service;
+
+import com.gbsw.snapy.domain.albums.entity.DailyAlbum;
+import com.gbsw.snapy.domain.albums.repository.DailyAlbumRepository;
+import com.gbsw.snapy.domain.audios.dto.response.AudioUploadResponse;
+import com.gbsw.snapy.domain.audios.entity.Audio;
+import com.gbsw.snapy.domain.audios.repository.AudioRepository;
+import com.gbsw.snapy.domain.audios.service.AudioService;
+import com.gbsw.snapy.domain.comments.dto.request.CommentUploadRequest;
+import com.gbsw.snapy.domain.comments.dto.response.CommentUploadResponse;
+import com.gbsw.snapy.domain.comments.entity.Comment;
+import com.gbsw.snapy.domain.comments.entity.CommentAttachment;
+import com.gbsw.snapy.domain.comments.repository.CommentAttachmentRepository;
+import com.gbsw.snapy.domain.comments.repository.CommentRepository;
+import com.gbsw.snapy.domain.photos.dto.response.PhotoUploadResponse;
+import com.gbsw.snapy.domain.photos.entity.Photo;
+import com.gbsw.snapy.domain.photos.entity.PhotoType;
+import com.gbsw.snapy.domain.photos.repository.PhotoRepository;
+import com.gbsw.snapy.domain.photos.service.PhotoService;
+import com.gbsw.snapy.domain.users.entity.User;
+import com.gbsw.snapy.domain.users.repository.UserRepository;
+import com.gbsw.snapy.global.exception.CustomException;
+import com.gbsw.snapy.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final CommentAttachmentRepository commentAttachmentRepository;
+
+    private final PhotoService photoService;
+    private final AudioService audioService;
+
+    private final UserRepository userRepository;
+    private final DailyAlbumRepository dailyAlbumRepository;
+    private final PhotoRepository photoRepository;
+    private final AudioRepository audioRepository;
+
+    @Transactional
+    public CommentUploadResponse upload(Long albumId, Long userId, CommentUploadRequest request) {
+        DailyAlbum album = dailyAlbumRepository.findById(albumId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        CommentAttachment attachment = switch (request.getType()) {
+            case EMOJI -> {
+                if (request.getEmojiValue() == null || request.getEmojiValue().isBlank()) {
+                    throw new CustomException(ErrorCode.INVALID_COMMENT_ATTACHMENT);
+                }
+                yield CommentAttachment.ofEmoji(request.getEmojiValue());
+            }
+            case IMAGE -> {
+                if (request.getFile() == null || request.getFile().isEmpty()) {
+                    throw new CustomException(ErrorCode.INVALID_COMMENT_ATTACHMENT);
+                }
+                PhotoUploadResponse response = photoService.upload(request.getFile(), userId, PhotoType.COMMENT);
+                Photo photo = photoRepository.findById(response.photoId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.IMAGE_NOT_FOUND));
+                yield CommentAttachment.ofImage(photo);
+            }
+            case AUDIO -> {
+                if (request.getFile() == null || request.getFile().isEmpty()) {
+                    throw new CustomException(ErrorCode.INVALID_COMMENT_ATTACHMENT);
+                }
+                AudioUploadResponse response = audioService.upload(request.getFile(), userId);
+                Audio audio = audioRepository.findById(response.audioId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.AUDIO_NOT_FOUND));
+                yield CommentAttachment.ofAudio(audio);
+            }
+        };
+
+        CommentAttachment savedAttachment = commentAttachmentRepository.save(attachment);
+        Comment comment = commentRepository.save(
+                Comment.builder()
+                        .album(album)
+                        .user(user)
+                        .attachment(savedAttachment)
+                        .build()
+        );
+
+        return CommentUploadResponse.from(comment);
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/photos/entity/PhotoType.java
+++ b/src/main/java/com/gbsw/snapy/domain/photos/entity/PhotoType.java
@@ -2,5 +2,6 @@ package com.gbsw.snapy.domain.photos.entity;
 
 public enum PhotoType {
     FRONT,
-    BACK
+    BACK,
+    COMMENT
 }

--- a/src/main/java/com/gbsw/snapy/global/common/CursorResponse.java
+++ b/src/main/java/com/gbsw/snapy/global/common/CursorResponse.java
@@ -1,0 +1,13 @@
+package com.gbsw.snapy.global.common;
+
+import java.util.List;
+
+public record CursorResponse<T>(
+        List<T> content,
+        Long nextCursor,
+        boolean hasNext
+) {
+    public static <T> CursorResponse<T> of(List<T> content, Long nextCursor, boolean hasNext) {
+        return new CursorResponse<>(content, nextCursor, hasNext);
+    }
+}

--- a/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
+++ b/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
@@ -68,7 +68,10 @@ public enum ErrorCode {
     FRIEND_REQUEST_ALREADY_SENT(HttpStatus.CONFLICT, "이미 친구 신청을 보냈습니다."),
     FRIEND_REQUEST_SELF(HttpStatus.BAD_REQUEST, "자기 자신에게 친구 신청을 할 수 없습니다."),
     FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "친구 신청을 찾을 수 없습니다."),
-    FRIEND_REQUEST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 친구 신청에 대한 권한이 없습니다.");
+    FRIEND_REQUEST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 친구 신청에 대한 권한이 없습니다."),
+
+    // Comment
+    INVALID_COMMENT_ATTACHMENT(HttpStatus.BAD_REQUEST, "댓글 첨부 데이터가 올바르지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
+++ b/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
@@ -71,6 +71,7 @@ public enum ErrorCode {
     FRIEND_REQUEST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 친구 신청에 대한 권한이 없습니다."),
 
     // Comment
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     INVALID_COMMENT_ATTACHMENT(HttpStatus.BAD_REQUEST, "댓글 첨부 데이터가 올바르지 않습니다.");
 
     private final HttpStatus status;


### PR DESCRIPTION
### Type of PR
feat

### Changes
**댓글 조회**
- url: `GET api/albums/{albumId}/comments?cursor=0&size=20`
- 해당 앨범에 작성된 댓글을 최신순으로 조회
- cursor 기반 페이지네이션 적용(기본 size = 20)

**댓글 작성**
- url: `POST api/albums/{albumId}/comments`
- 해당 앨범에 댓글을 작성
- type: EMOJI, IMAGE, AUDIO

**댓글 삭제**
- url `DELETE api/comments/{commentId}`
- 해당 댓글을 삭제
- 작성자만 삭제 가능

### Additional

close #40 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 앨범에 댓글을 추가할 수 있으며, 이모지, 이미지, 오디오 첨부 지원
  * 댓글 목록을 커서 기반 페이지네이션으로 조회 가능
  * 댓글 삭제 기능 추가 (본인 댓글만 삭제 가능)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->