### PR TITLE
feat: 스토리 좋아요 토글 및 좋아요 목록 조회 api 추가

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/stories/controller/StoryController.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/controller/StoryController.java
@@ -1,6 +1,8 @@
 package com.gbsw.snapy.domain.stories.controller;
 
 import com.gbsw.snapy.domain.stories.dto.response.StoryDetailResponse;
+import com.gbsw.snapy.domain.stories.dto.response.StoryLikeListResponse;
+import com.gbsw.snapy.domain.stories.dto.response.StoryLikeResponse;
 import com.gbsw.snapy.domain.stories.dto.response.StoryListResponse;
 import com.gbsw.snapy.domain.stories.service.StoryService;
 import com.gbsw.snapy.global.common.ApiResponse;
@@ -33,6 +35,24 @@ public class StoryController {
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
         StoryDetailResponse response = storyService.getStoryDetail(storyId, principal.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/{storyId}/likes")
+    public ResponseEntity<ApiResponse<StoryLikeResponse>> toggleLike(
+            @PathVariable Long storyId,
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        StoryLikeResponse response = storyService.toggleLike(storyId, principal.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{storyId}/likes")
+    public ResponseEntity<ApiResponse<List<StoryLikeListResponse>>> getLikes(
+            @PathVariable Long storyId,
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        List<StoryLikeListResponse> response = storyService.getLikes(storyId, principal.getId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/stories/dto/response/StoryLikeListResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/dto/response/StoryLikeListResponse.java
@@ -1,0 +1,12 @@
+package com.gbsw.snapy.domain.stories.dto.response;
+
+import java.time.LocalDateTime;
+
+public record StoryLikeListResponse(
+        Long userId,
+        String handle,
+        String username,
+        String profileImageUrl,
+        LocalDateTime likedAt
+) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/stories/dto/response/StoryLikeResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/dto/response/StoryLikeResponse.java
@@ -1,0 +1,8 @@
+package com.gbsw.snapy.domain.stories.dto.response;
+
+public record StoryLikeResponse(
+        Long storyId,
+        boolean liked,
+        long likeCount
+) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/stories/entity/StoryLike.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/entity/StoryLike.java
@@ -1,0 +1,35 @@
+package com.gbsw.snapy.domain.stories.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "story_likes", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"story_id", "user_id"})
+})
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class StoryLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "story_id", nullable = false)
+    private Long storyId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryLikeRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryLikeRepository.java
@@ -1,0 +1,18 @@
+package com.gbsw.snapy.domain.stories.repository;
+
+import com.gbsw.snapy.domain.stories.entity.StoryLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StoryLikeRepository extends JpaRepository<StoryLike, Long> {
+
+    Optional<StoryLike> findByStoryIdAndUserId(Long storyId, Long userId);
+
+    long countByStoryId(Long storyId);
+
+    boolean existsByStoryIdAndUserId(Long storyId, Long userId);
+
+    List<StoryLike> findByStoryIdOrderByCreatedAtDesc(Long storyId);
+}

--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -246,6 +246,24 @@ public class StoryService {
             throw new CustomException(ErrorCode.STORY_EXPIRED);
         }
 
+        Long ownerId = story.getUserId();
+        if (!ownerId.equals(userId)) {
+            Visibility feedVisibility = userSettingRepository.findById(ownerId)
+                    .map(UserSetting::getFeedVisibility)
+                    .orElse(Visibility.FRIENDS_ONLY);
+
+            if (feedVisibility == Visibility.ONLY_ME) {
+                throw new CustomException(ErrorCode.ACCESS_DENIED);
+            }
+
+            if (feedVisibility == Visibility.FRIENDS_ONLY) {
+                boolean isFriend = friendRepository.existsFriendship(userId, ownerId);
+                if (!isFriend) {
+                    throw new CustomException(ErrorCode.ACCESS_DENIED);
+                }
+            }
+        }
+
         Optional<StoryLike> existing = storyLikeRepository.findByStoryIdAndUserId(storyId, userId);
 
         boolean liked;

--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -9,9 +9,13 @@ import com.gbsw.snapy.domain.settings.entity.UserSetting;
 import com.gbsw.snapy.domain.settings.entity.Visibility;
 import com.gbsw.snapy.domain.settings.repository.UserSettingRepository;
 import com.gbsw.snapy.domain.stories.dto.response.StoryDetailResponse;
+import com.gbsw.snapy.domain.stories.dto.response.StoryLikeListResponse;
+import com.gbsw.snapy.domain.stories.dto.response.StoryLikeResponse;
 import com.gbsw.snapy.domain.stories.dto.response.StoryListResponse;
 import com.gbsw.snapy.domain.stories.entity.Story;
+import com.gbsw.snapy.domain.stories.entity.StoryLike;
 import com.gbsw.snapy.domain.stories.entity.StoryPhoto;
+import com.gbsw.snapy.domain.stories.repository.StoryLikeRepository;
 import com.gbsw.snapy.domain.stories.repository.StoryPhotoRepository;
 import com.gbsw.snapy.domain.stories.repository.StoryRepository;
 import com.gbsw.snapy.domain.users.entity.User;
@@ -28,6 +32,7 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -37,6 +42,7 @@ public class StoryService {
 
     private final StoryRepository storyRepository;
     private final StoryPhotoRepository storyPhotoRepository;
+    private final StoryLikeRepository storyLikeRepository;
     private final FriendRepository friendRepository;
     private final UserRepository userRepository;
     private final PhotoRepository photoRepository;
@@ -228,5 +234,70 @@ public class StoryService {
                 story.getCreatedAt(),
                 story.getExpiresAt()
         );
+    }
+
+    @Transactional
+    public StoryLikeResponse toggleLike(Long storyId, Long userId) {
+        Story story = storyRepository.findById(storyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORY_NOT_FOUND));
+
+        LocalDateTime nowKst = LocalDateTime.now(KST_ZONE);
+        if (story.isExpired(nowKst)) {
+            throw new CustomException(ErrorCode.STORY_EXPIRED);
+        }
+
+        Optional<StoryLike> existing = storyLikeRepository.findByStoryIdAndUserId(storyId, userId);
+
+        boolean liked;
+        if (existing.isPresent()) {
+            storyLikeRepository.delete(existing.get());
+            liked = false;
+        } else {
+            storyLikeRepository.save(
+                    StoryLike.builder()
+                            .storyId(storyId)
+                            .userId(userId)
+                            .build()
+            );
+            liked = true;
+        }
+
+        long likeCount = storyLikeRepository.countByStoryId(storyId);
+        return new StoryLikeResponse(storyId, liked, likeCount);
+    }
+
+    @Transactional(readOnly = true)
+    public List<StoryLikeListResponse> getLikes(Long storyId, Long userId) {
+        Story story = storyRepository.findById(storyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORY_NOT_FOUND));
+
+        if (!story.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        List<StoryLike> likes = storyLikeRepository.findByStoryIdOrderByCreatedAtDesc(storyId);
+        if (likes.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> likeUserIds = likes.stream().map(StoryLike::getUserId).toList();
+        Map<Long, User> userMap = userRepository.findAllById(likeUserIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        List<StoryLikeListResponse> result = new ArrayList<>();
+        for (StoryLike like : likes) {
+            User user = userMap.get(like.getUserId());
+            if (user == null) continue;
+
+            result.add(new StoryLikeListResponse(
+                    user.getId(),
+                    user.getHandle(),
+                    user.getUsername(),
+                    user.getProfileImageUrl(),
+                    like.getCreatedAt()
+            ));
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
### Type of PR
feat
### Changes
- StoryLike 엔티티 및 리포지토리 추가 (story_id + user_id 유니크 제약)
- POST /api/stories/{storyId}/likes 좋아요 토글 api 추가
- GET /api/stories/{storyId}/likes 좋아요 목록 조회 api 추가 (본인 스토리만)
### Additional
- 좋아요 토글은 만료된 스토리에 대해 STORY_EXPIRED 반환
- 좋아요 목록 조회는 본인 스토리가 아닌 경우 ACCESS_DENIED 반환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 스토리 좋아요 토글 기능 추가 - 사용자가 스토리에 좋아요를 누르고 취소할 수 있습니다.
* 좋아요 목록 조회 기능 추가 - 스토리 소유자가 좋아요를 누른 사용자의 프로필 정보와 좋아요 시간을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->