### PR TITLE
refactor: 스토리 좋아요 토글 응답에서 likeCount 제거

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/stories/dto/response/StoryLikeResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/dto/response/StoryLikeResponse.java
@@ -2,7 +2,6 @@ package com.gbsw.snapy.domain.stories.dto.response;
 
 public record StoryLikeResponse(
         Long storyId,
-        boolean liked,
-        long likeCount
+        boolean liked
 ) {
 }

--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -280,8 +280,7 @@ public class StoryService {
             liked = true;
         }
 
-        long likeCount = storyLikeRepository.countByStoryId(storyId);
-        return new StoryLikeResponse(storyId, liked, likeCount);
+        return new StoryLikeResponse(storyId, liked);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
### Type of PR
refactor
### Changes
  - StoryLikeResponse에서 likeCount 필드 제거
  - StoryService.toggleLike()에서 countByStoryId 쿼리 호출 제거
### Additional
- 좋아요 수는 스토리 주인만 좋아요 목록 조회 API(GET /api/stories/{storyId}/likes)에서 확인 가능
- close #78 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항
* 스토리 좋아요 기능의 응답이 최적화되었습니다. 좋아요를 토글할 때 반환되는 응답에서 좋아요 총 개수 정보가 제거되었습니다. 이제 응답에는 스토리 ID와 현재 좋아요 여부 정보만 포함됩니다.
* 스토리 좋아요 토글 동작과 모든 권한 및 가시성 검증은 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->