### PR TITLE
feat: 알림 도메인 및 이벤트 기반 알림 생성 로직 추가

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -27,6 +27,7 @@ import com.gbsw.snapy.domain.settings.entity.UserSetting;
 import com.gbsw.snapy.domain.settings.entity.Visibility;
 import com.gbsw.snapy.domain.settings.repository.UserSettingRepository;
 import com.gbsw.snapy.domain.notifications.event.AlbumPublishedEvent;
+import com.gbsw.snapy.domain.notifications.event.NewStoryEvent;
 import com.gbsw.snapy.infra.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,6 +48,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -124,15 +126,25 @@ public class AlbumService {
                         .build()
         );
 
+        Optional<Story> existingStory = storyRepository.findByUserIdAndAlbumId(userId, album.getId());
         Story story;
-        try {
-            story = storyRepository.findByUserIdAndAlbumId(userId, album.getId())
-                    .orElseGet(() -> storyService.createStory(userId, album.getId()));
-        } catch (DataIntegrityViolationException e) {
-            story = storyRepository.findByUserIdAndAlbumId(userId, album.getId())
-                    .orElseThrow(() -> e);
+        boolean storyCreated = false;
+        if (existingStory.isPresent()) {
+            story = existingStory.get();
+        } else {
+            try {
+                story = storyService.createStory(userId, album.getId());
+                storyCreated = true;
+            } catch (DataIntegrityViolationException e) {
+                story = storyRepository.findByUserIdAndAlbumId(userId, album.getId())
+                        .orElseThrow(() -> e);
+            }
         }
         storyService.addPhotos(story.getId(), frontPhoto.photoId(), backPhoto.photoId(), request.getType());
+
+        if (storyCreated) {
+            eventPublisher.publishEvent(new NewStoryEvent(story.getId(), userId));
+        }
 
         return AlbumUploadResponse.from(album, request.getType());
     }

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -26,9 +26,11 @@ import com.gbsw.snapy.domain.friends.repository.FriendRepository;
 import com.gbsw.snapy.domain.settings.entity.UserSetting;
 import com.gbsw.snapy.domain.settings.entity.Visibility;
 import com.gbsw.snapy.domain.settings.repository.UserSettingRepository;
+import com.gbsw.snapy.domain.notifications.event.AlbumPublishedEvent;
 import com.gbsw.snapy.infra.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -60,6 +62,7 @@ public class AlbumService {
     private final StoryRepository storyRepository;
     private final UserSettingRepository userSettingRepository;
     private final FriendRepository friendRepository;
+    private final ApplicationEventPublisher eventPublisher;
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
     @Transactional
@@ -376,6 +379,8 @@ public class AlbumService {
         }
 
         album.publish();
+
+        eventPublisher.publishEvent(new AlbumPublishedEvent(album.getId(), userId));
 
         return AlbumPublishResponse.from(album);
     }

--- a/src/main/java/com/gbsw/snapy/domain/friends/service/FriendService.java
+++ b/src/main/java/com/gbsw/snapy/domain/friends/service/FriendService.java
@@ -16,7 +16,10 @@ import com.gbsw.snapy.domain.users.entity.User;
 import com.gbsw.snapy.domain.users.repository.UserRepository;
 import com.gbsw.snapy.global.exception.CustomException;
 import com.gbsw.snapy.global.exception.ErrorCode;
+import com.gbsw.snapy.domain.notifications.event.FriendAcceptedEvent;
+import com.gbsw.snapy.domain.notifications.event.FriendRequestEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,7 +33,9 @@ public class FriendService {
     private final FriendRequestRepository friendRequestRepository;
     private final FriendRepository friendRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
+    @Transactional
     public void sendRequest(Long senderId, String receiverHandle) {
         User receiver = userRepository.findByHandle(receiverHandle)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -47,10 +52,13 @@ public class FriendService {
             throw new CustomException(ErrorCode.FRIEND_REQUEST_ALREADY_SENT);
         }
 
-        friendRequestRepository.save(FriendRequest.builder()
+        FriendRequest savedRequest = friendRequestRepository.save(FriendRequest.builder()
                 .senderId(senderId)
                 .receiverId(receiver.getId())
                 .build());
+
+        eventPublisher.publishEvent(new FriendRequestEvent(
+                savedRequest.getId(), senderId, receiver.getId()));
     }
 
     public FriendRequestStatusResponse getRequestStatus(Long senderId, String receiverHandle) {
@@ -128,6 +136,9 @@ public class FriendService {
             Long userAId = Math.min(request.getSenderId(), request.getReceiverId());
             Long userBId = Math.max(request.getSenderId(), request.getReceiverId());
             friendRepository.save(Friend.builder().id(new FriendId(userAId, userBId)).build());
+
+            eventPublisher.publishEvent(new FriendAcceptedEvent(
+                    request.getSenderId(), receiverId));
         }
 
         friendRequestRepository.delete(request);

--- a/src/main/java/com/gbsw/snapy/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/controller/NotificationController.java
@@ -1,0 +1,54 @@
+package com.gbsw.snapy.domain.notifications.controller;
+
+import com.gbsw.snapy.domain.notifications.dto.response.NotificationResponse;
+import com.gbsw.snapy.domain.notifications.dto.response.UnreadCountResponse;
+import com.gbsw.snapy.domain.notifications.service.NotificationService;
+import com.gbsw.snapy.global.common.ApiResponse;
+import com.gbsw.snapy.global.security.CustomUserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<NotificationResponse>>> getNotifications(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        List<NotificationResponse> response = notificationService.getNotifications(principal.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/unread-count")
+    public ResponseEntity<ApiResponse<UnreadCountResponse>> getUnreadCount(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        UnreadCountResponse response = notificationService.getUnreadCount(principal.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PatchMapping("/{id}/read")
+    public ResponseEntity<ApiResponse<Void>> markAsRead(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        notificationService.markAsRead(id, principal.getId());
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PatchMapping("/read-all")
+    public ResponseEntity<ApiResponse<Void>> markAllAsRead(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        notificationService.markAllAsRead(principal.getId());
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/controller/NotificationController.java
@@ -1,16 +1,16 @@
 package com.gbsw.snapy.domain.notifications.controller;
 
-import com.gbsw.snapy.domain.notifications.dto.response.NotificationResponse;
+import com.gbsw.snapy.domain.notifications.dto.response.NotificationPageResponse;
 import com.gbsw.snapy.domain.notifications.dto.response.UnreadCountResponse;
 import com.gbsw.snapy.domain.notifications.service.NotificationService;
 import com.gbsw.snapy.global.common.ApiResponse;
 import com.gbsw.snapy.global.security.CustomUserPrincipal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,10 +20,14 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<NotificationResponse>>> getNotifications(
+    public ResponseEntity<ApiResponse<NotificationPageResponse>> getNotifications(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        List<NotificationResponse> response = notificationService.getNotifications(principal.getId());
+        int safeSize = Math.min(Math.max(size, 1), 50);
+        Pageable pageable = PageRequest.of(Math.max(page, 0), safeSize);
+        NotificationPageResponse response = notificationService.getNotifications(principal.getId(), pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/gbsw/snapy/domain/notifications/dto/response/NotificationPageResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/dto/response/NotificationPageResponse.java
@@ -1,0 +1,21 @@
+package com.gbsw.snapy.domain.notifications.dto.response;
+
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public record NotificationPageResponse(
+        List<NotificationResponse> items,
+        int page,
+        int size,
+        boolean hasNext
+) {
+    public static NotificationPageResponse of(Slice<NotificationResponse> slice) {
+        return new NotificationPageResponse(
+                slice.getContent(),
+                slice.getNumber(),
+                slice.getSize(),
+                slice.hasNext()
+        );
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/dto/response/NotificationResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/dto/response/NotificationResponse.java
@@ -1,0 +1,35 @@
+package com.gbsw.snapy.domain.notifications.dto.response;
+
+import com.gbsw.snapy.domain.notifications.entity.Notification;
+import com.gbsw.snapy.domain.notifications.entity.NotificationType;
+
+import java.time.LocalDateTime;
+
+public record NotificationResponse(
+        Long id,
+        Long senderId,
+        String senderHandle,
+        String senderUsername,
+        String senderProfileImageUrl,
+        NotificationType type,
+        Long referenceId,
+        boolean read,
+        LocalDateTime createdAt
+) {
+    public static NotificationResponse of(Notification notification,
+                                           String senderHandle,
+                                           String senderUsername,
+                                           String senderProfileImageUrl) {
+        return new NotificationResponse(
+                notification.getId(),
+                notification.getSenderId(),
+                senderHandle,
+                senderUsername,
+                senderProfileImageUrl,
+                notification.getType(),
+                notification.getReferenceId(),
+                notification.isRead(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/dto/response/UnreadCountResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/dto/response/UnreadCountResponse.java
@@ -1,0 +1,4 @@
+package com.gbsw.snapy.domain.notifications.dto.response;
+
+public record UnreadCountResponse(long count) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/entity/Notification.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/entity/Notification.java
@@ -1,0 +1,49 @@
+package com.gbsw.snapy.domain.notifications.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications", indexes = {
+        @Index(name = "idx_notification_receiver", columnList = "receiver_id, is_read, created_at")
+})
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "receiver_id", nullable = false)
+    private Long receiverId;
+
+    @Column(name = "sender_id", nullable = false)
+    private Long senderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private NotificationType type;
+
+    @Column(name = "reference_id")
+    private Long referenceId;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean read;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void markAsRead() {
+        this.read = true;
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/entity/Notification.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/entity/Notification.java
@@ -7,7 +7,8 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "notifications", indexes = {
-        @Index(name = "idx_notification_receiver", columnList = "receiver_id, is_read, created_at")
+        @Index(name = "idx_notification_receiver_created", columnList = "receiver_id, created_at"),
+        @Index(name = "idx_notification_receiver_unread", columnList = "receiver_id, is_read")
 })
 @Getter
 @Builder

--- a/src/main/java/com/gbsw/snapy/domain/notifications/entity/NotificationType.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/entity/NotificationType.java
@@ -1,0 +1,9 @@
+package com.gbsw.snapy.domain.notifications.entity;
+
+public enum NotificationType {
+    STORY_LIKE,
+    FRIEND_REQUEST,
+    FRIEND_ACCEPTED,
+    ALBUM_PUBLISHED,
+    NEW_STORY
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/AlbumPublishedEvent.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/AlbumPublishedEvent.java
@@ -1,0 +1,4 @@
+package com.gbsw.snapy.domain.notifications.event;
+
+public record AlbumPublishedEvent(Long albumId, Long userId) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/FriendAcceptedEvent.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/FriendAcceptedEvent.java
@@ -1,0 +1,4 @@
+package com.gbsw.snapy.domain.notifications.event;
+
+public record FriendAcceptedEvent(Long senderId, Long receiverId) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/FriendRequestEvent.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/FriendRequestEvent.java
@@ -1,0 +1,4 @@
+package com.gbsw.snapy.domain.notifications.event;
+
+public record FriendRequestEvent(Long requestId, Long senderId, Long receiverId) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/NewStoryEvent.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/NewStoryEvent.java
@@ -1,0 +1,4 @@
+package com.gbsw.snapy.domain.notifications.event;
+
+public record NewStoryEvent(Long storyId, Long userId) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
@@ -61,31 +61,33 @@ public class NotificationEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleAlbumPublished(AlbumPublishedEvent event) {
-        try {
-            List<Long> friendIds = friendRepository.findFriendIdsByUserId(event.userId());
-            for (Long friendId : friendIds) {
+        List<Long> friendIds = friendRepository.findFriendIdsByUserId(event.userId());
+        for (Long friendId : friendIds) {
+            try {
                 notificationService.create(
                         friendId, event.userId(),
                         NotificationType.ALBUM_PUBLISHED, event.albumId()
                 );
+            } catch (Exception e) {
+                log.warn("앨범 게시 알림 생성 실패 - albumId: {}, friendId: {}",
+                        event.albumId(), friendId, e);
             }
-        } catch (Exception e) {
-            log.warn("앨범 게시 알림 생성 실패 - albumId: {}", event.albumId(), e);
         }
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleNewStory(NewStoryEvent event) {
-        try {
-            List<Long> friendIds = friendRepository.findFriendIdsByUserId(event.userId());
-            for (Long friendId : friendIds) {
+        List<Long> friendIds = friendRepository.findFriendIdsByUserId(event.userId());
+        for (Long friendId : friendIds) {
+            try {
                 notificationService.create(
                         friendId, event.userId(),
                         NotificationType.NEW_STORY, event.storyId()
                 );
+            } catch (Exception e) {
+                log.warn("새 스토리 알림 생성 실패 - storyId: {}, friendId: {}",
+                        event.storyId(), friendId, e);
             }
-        } catch (Exception e) {
-            log.warn("새 스토리 알림 생성 실패 - storyId: {}", event.storyId(), e);
         }
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
@@ -1,0 +1,91 @@
+package com.gbsw.snapy.domain.notifications.event;
+
+import com.gbsw.snapy.domain.friends.repository.FriendRepository;
+import com.gbsw.snapy.domain.notifications.entity.NotificationType;
+import com.gbsw.snapy.domain.notifications.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final NotificationService notificationService;
+    private final FriendRepository friendRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleStoryLiked(StoryLikedEvent event) {
+        if (event.senderId().equals(event.ownerId())) {
+            return;
+        }
+
+        try {
+            notificationService.create(
+                    event.ownerId(), event.senderId(),
+                    NotificationType.STORY_LIKE, event.storyId()
+            );
+        } catch (Exception e) {
+            log.warn("스토리 좋아요 알림 생성 실패 - storyId: {}", event.storyId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFriendRequest(FriendRequestEvent event) {
+        try {
+            notificationService.create(
+                    event.receiverId(), event.senderId(),
+                    NotificationType.FRIEND_REQUEST, event.requestId()
+            );
+        } catch (Exception e) {
+            log.warn("친구 요청 알림 생성 실패 - requestId: {}", event.requestId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFriendAccepted(FriendAcceptedEvent event) {
+        try {
+            notificationService.create(
+                    event.senderId(), event.receiverId(),
+                    NotificationType.FRIEND_ACCEPTED, null
+            );
+        } catch (Exception e) {
+            log.warn("친구 수락 알림 생성 실패", e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleAlbumPublished(AlbumPublishedEvent event) {
+        try {
+            List<Long> friendIds = friendRepository.findFriendIdsByUserId(event.userId());
+            for (Long friendId : friendIds) {
+                notificationService.create(
+                        friendId, event.userId(),
+                        NotificationType.ALBUM_PUBLISHED, event.albumId()
+                );
+            }
+        } catch (Exception e) {
+            log.warn("앨범 게시 알림 생성 실패 - albumId: {}", event.albumId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleNewStory(NewStoryEvent event) {
+        try {
+            List<Long> friendIds = friendRepository.findFriendIdsByUserId(event.userId());
+            for (Long friendId : friendIds) {
+                notificationService.create(
+                        friendId, event.userId(),
+                        NotificationType.NEW_STORY, event.storyId()
+                );
+            }
+        } catch (Exception e) {
+            log.warn("새 스토리 알림 생성 실패 - storyId: {}", event.storyId(), e);
+        }
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/StoryLikedEvent.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/StoryLikedEvent.java
@@ -1,0 +1,4 @@
+package com.gbsw.snapy.domain.notifications.event;
+
+public record StoryLikedEvent(Long storyId, Long senderId, Long ownerId) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/repository/NotificationRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/repository/NotificationRepository.java
@@ -1,0 +1,19 @@
+package com.gbsw.snapy.domain.notifications.repository;
+
+import com.gbsw.snapy.domain.notifications.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByReceiverIdOrderByCreatedAtDesc(Long receiverId);
+
+    long countByReceiverIdAndReadFalse(Long receiverId);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.read = true WHERE n.receiverId = :receiverId AND n.read = false")
+    void markAllAsRead(Long receiverId);
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/repository/NotificationRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/repository/NotificationRepository.java
@@ -4,6 +4,7 @@ import com.gbsw.snapy.domain.notifications.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -15,5 +16,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     @Modifying
     @Query("UPDATE Notification n SET n.read = true WHERE n.receiverId = :receiverId AND n.read = false")
-    void markAllAsRead(Long receiverId);
+    void markAllAsRead(@Param("receiverId") Long receiverId);
 }

--- a/src/main/java/com/gbsw/snapy/domain/notifications/repository/NotificationRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/repository/NotificationRepository.java
@@ -1,16 +1,16 @@
 package com.gbsw.snapy.domain.notifications.repository;
 
 import com.gbsw.snapy.domain.notifications.entity.Notification;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    List<Notification> findByReceiverIdOrderByCreatedAtDesc(Long receiverId);
+    Slice<Notification> findByReceiverIdOrderByCreatedAtDesc(Long receiverId, Pageable pageable);
 
     long countByReceiverIdAndReadFalse(Long receiverId);
 

--- a/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
@@ -1,5 +1,6 @@
 package com.gbsw.snapy.domain.notifications.service;
 
+import com.gbsw.snapy.domain.notifications.dto.response.NotificationPageResponse;
 import com.gbsw.snapy.domain.notifications.dto.response.NotificationResponse;
 import com.gbsw.snapy.domain.notifications.dto.response.UnreadCountResponse;
 import com.gbsw.snapy.domain.notifications.entity.Notification;
@@ -10,6 +11,9 @@ import com.gbsw.snapy.domain.users.repository.UserRepository;
 import com.gbsw.snapy.global.exception.CustomException;
 import com.gbsw.snapy.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,15 +43,15 @@ public class NotificationService {
     }
 
     @Transactional(readOnly = true)
-    public List<NotificationResponse> getNotifications(Long userId) {
-        List<Notification> notifications = notificationRepository
-                .findByReceiverIdOrderByCreatedAtDesc(userId);
+    public NotificationPageResponse getNotifications(Long userId, Pageable pageable) {
+        Slice<Notification> slice = notificationRepository
+                .findByReceiverIdOrderByCreatedAtDesc(userId, pageable);
 
-        if (notifications.isEmpty()) {
-            return List.of();
+        if (!slice.hasContent()) {
+            return NotificationPageResponse.of(new SliceImpl<>(List.of(), pageable, false));
         }
 
-        List<Long> senderIds = notifications.stream()
+        List<Long> senderIds = slice.getContent().stream()
                 .map(Notification::getSenderId)
                 .distinct()
                 .toList();
@@ -55,10 +59,10 @@ public class NotificationService {
         Map<Long, User> userMap = userRepository.findAllById(senderIds).stream()
                 .collect(Collectors.toMap(User::getId, Function.identity()));
 
-        List<NotificationResponse> result = new ArrayList<>();
-        for (Notification notification : notifications) {
+        List<NotificationResponse> items = new ArrayList<>();
+        for (Notification notification : slice.getContent()) {
             User sender = userMap.get(notification.getSenderId());
-            result.add(NotificationResponse.of(
+            items.add(NotificationResponse.of(
                     notification,
                     sender != null ? sender.getHandle() : null,
                     sender != null ? sender.getUsername() : null,
@@ -66,7 +70,8 @@ public class NotificationService {
             ));
         }
 
-        return result;
+        Slice<NotificationResponse> mapped = new SliceImpl<>(items, pageable, slice.hasNext());
+        return NotificationPageResponse.of(mapped);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
@@ -1,0 +1,94 @@
+package com.gbsw.snapy.domain.notifications.service;
+
+import com.gbsw.snapy.domain.notifications.dto.response.NotificationResponse;
+import com.gbsw.snapy.domain.notifications.dto.response.UnreadCountResponse;
+import com.gbsw.snapy.domain.notifications.entity.Notification;
+import com.gbsw.snapy.domain.notifications.entity.NotificationType;
+import com.gbsw.snapy.domain.notifications.repository.NotificationRepository;
+import com.gbsw.snapy.domain.users.entity.User;
+import com.gbsw.snapy.domain.users.repository.UserRepository;
+import com.gbsw.snapy.global.exception.CustomException;
+import com.gbsw.snapy.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+
+    public void create(Long receiverId, Long senderId, NotificationType type, Long referenceId) {
+        notificationRepository.save(
+                Notification.builder()
+                        .receiverId(receiverId)
+                        .senderId(senderId)
+                        .type(type)
+                        .referenceId(referenceId)
+                        .read(false)
+                        .build()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> getNotifications(Long userId) {
+        List<Notification> notifications = notificationRepository
+                .findByReceiverIdOrderByCreatedAtDesc(userId);
+
+        if (notifications.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> senderIds = notifications.stream()
+                .map(Notification::getSenderId)
+                .distinct()
+                .toList();
+
+        Map<Long, User> userMap = userRepository.findAllById(senderIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        List<NotificationResponse> result = new ArrayList<>();
+        for (Notification notification : notifications) {
+            User sender = userMap.get(notification.getSenderId());
+            result.add(NotificationResponse.of(
+                    notification,
+                    sender != null ? sender.getHandle() : null,
+                    sender != null ? sender.getUsername() : null,
+                    sender != null ? sender.getProfileImageUrl() : null
+            ));
+        }
+
+        return result;
+    }
+
+    @Transactional(readOnly = true)
+    public UnreadCountResponse getUnreadCount(Long userId) {
+        long count = notificationRepository.countByReceiverIdAndReadFalse(userId);
+        return new UnreadCountResponse(count);
+    }
+
+    @Transactional
+    public void markAsRead(Long notificationId, Long userId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.getReceiverId().equals(userId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        notification.markAsRead();
+    }
+
+    @Transactional
+    public void markAllAsRead(Long userId) {
+        notificationRepository.markAllAsRead(userId);
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -22,7 +22,10 @@ import com.gbsw.snapy.domain.users.entity.User;
 import com.gbsw.snapy.domain.users.repository.UserRepository;
 import com.gbsw.snapy.global.exception.CustomException;
 import com.gbsw.snapy.global.exception.ErrorCode;
+import com.gbsw.snapy.domain.notifications.event.NewStoryEvent;
+import com.gbsw.snapy.domain.notifications.event.StoryLikedEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,19 +50,24 @@ public class StoryService {
     private final UserRepository userRepository;
     private final PhotoRepository photoRepository;
     private final UserSettingRepository userSettingRepository;
+    private final ApplicationEventPublisher eventPublisher;
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Story createStory(Long userId, Long albumId) {
         LocalDateTime nowKst = LocalDateTime.now(KST_ZONE);
 
-        return storyRepository.save(
+        Story story = storyRepository.save(
                 Story.builder()
                         .userId(userId)
                         .albumId(albumId)
                         .expiresAt(nowKst.plusHours(24))
                         .build()
         );
+
+        eventPublisher.publishEvent(new NewStoryEvent(story.getId(), userId));
+
+        return story;
     }
 
     @Transactional
@@ -278,6 +286,8 @@ public class StoryService {
                             .build()
             );
             liked = true;
+
+            eventPublisher.publishEvent(new StoryLikedEvent(storyId, userId, story.getUserId()));
         }
 
         return new StoryLikeResponse(storyId, liked);

--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -22,7 +22,6 @@ import com.gbsw.snapy.domain.users.entity.User;
 import com.gbsw.snapy.domain.users.repository.UserRepository;
 import com.gbsw.snapy.global.exception.CustomException;
 import com.gbsw.snapy.global.exception.ErrorCode;
-import com.gbsw.snapy.domain.notifications.event.NewStoryEvent;
 import com.gbsw.snapy.domain.notifications.event.StoryLikedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -57,17 +56,13 @@ public class StoryService {
     public Story createStory(Long userId, Long albumId) {
         LocalDateTime nowKst = LocalDateTime.now(KST_ZONE);
 
-        Story story = storyRepository.save(
+        return storyRepository.save(
                 Story.builder()
                         .userId(userId)
                         .albumId(albumId)
                         .expiresAt(nowKst.plusHours(24))
                         .build()
         );
-
-        eventPublisher.publishEvent(new NewStoryEvent(story.getId(), userId));
-
-        return story;
     }
 
     @Transactional


### PR DESCRIPTION
### Type of PR
feat
### Changes
  - Notification 엔티티, NotificationType enum(STORY_LIKE/FRIEND_REQUEST/FRIEND_ACCEPTED/ALBUM_PUBLISHED/NEW_STORY), Repository 추가
  - NotificationService: 목록 조회, 안 읽은 개수, 읽음 처리, 전체 읽음 처리
  - NotificationController: GET /api/notifications, GET /unread-count, PATCH /{id}/read, PATCH /read-all
  - 5개 이벤트 클래스 + NotificationEventListener (@TransactionalEventListener AFTER_COMMIT)
  - StoryService/FriendService/AlbumService에 ApplicationEventPublisher 주입 및 이벤트 발행
  - FriendService.sendRequest()에 @Transactional 추가 (이벤트 리스너 동작 위해)
### Additional
  - AFTER_COMMIT 사용으로 알림 실패가 원 비즈니스 로직(좋아요/친구요청 등)을 롤백시키지 않음
  - 리스너 내부 try-catch로 알림 생성 실패 시 로그만 남기고 삼킴
  - (receiver_id, is_read, created_at) 복합 인덱스로 목록/unread 조회 최적화
  - close #81 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**신규 기능**
- 알림 시스템 추가: 친구 요청, 앨범 공개, 스토리 좋아요, 친구의 새 스토리 게시 시 알림 수신 가능
- 알림 조회, 미읽음 개수 확인 기능 제공
- 개별 또는 일괄 읽음 표시 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->