### PR TITLE
feat: 본인 스토리 좋아요 차단

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
@@ -21,10 +21,6 @@ public class NotificationEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleStoryLiked(StoryLikedEvent event) {
-        if (event.senderId().equals(event.ownerId())) {
-            return;
-        }
-
         try {
             notificationService.create(
                     event.ownerId(), event.senderId(),

--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -250,20 +250,22 @@ public class StoryService {
         }
 
         Long ownerId = story.getUserId();
-        if (!ownerId.equals(userId)) {
-            Visibility feedVisibility = userSettingRepository.findById(ownerId)
-                    .map(UserSetting::getFeedVisibility)
-                    .orElse(Visibility.FRIENDS_ONLY);
+        if (ownerId.equals(userId)) {
+            throw new CustomException(ErrorCode.CANNOT_LIKE_OWN_STORY);
+        }
 
-            if (feedVisibility == Visibility.ONLY_ME) {
+        Visibility feedVisibility = userSettingRepository.findById(ownerId)
+                .map(UserSetting::getFeedVisibility)
+                .orElse(Visibility.FRIENDS_ONLY);
+
+        if (feedVisibility == Visibility.ONLY_ME) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        if (feedVisibility == Visibility.FRIENDS_ONLY) {
+            boolean isFriend = friendRepository.existsFriendship(userId, ownerId);
+            if (!isFriend) {
                 throw new CustomException(ErrorCode.ACCESS_DENIED);
-            }
-
-            if (feedVisibility == Visibility.FRIENDS_ONLY) {
-                boolean isFriend = friendRepository.existsFriendship(userId, ownerId);
-                if (!isFriend) {
-                    throw new CustomException(ErrorCode.ACCESS_DENIED);
-                }
             }
         }
 
@@ -282,7 +284,7 @@ public class StoryService {
             );
             liked = true;
 
-            eventPublisher.publishEvent(new StoryLikedEvent(storyId, userId, story.getUserId()));
+            eventPublisher.publishEvent(new StoryLikedEvent(storyId, userId, ownerId));
         }
 
         return new StoryLikeResponse(storyId, liked);

--- a/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
+++ b/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
     // Story
     STORY_NOT_FOUND(HttpStatus.NOT_FOUND, "스토리를 찾을 수 없습니다."),
     STORY_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 스토리입니다."),
+    CANNOT_LIKE_OWN_STORY(HttpStatus.BAD_REQUEST, "본인의 스토리에는 좋아요를 누를 수 없습니다."),
 
     // Notification
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),


### PR DESCRIPTION
### Type of PR
feat
### Changes
- ErrorCode에 CANNOT_LIKE_OWN_STORY (400) 추가
- StoryService.toggleLike() 진입부에 소유자 검증 추가 (본인 스토리면 CANNOT_LIKE_OWN_STORY 예외)
- 소유자가 선차단되므로 공개 범위 검증 블록의 if (!ownerId.equals(userId)) 래퍼 제거
- NotificationEventListener.handleStoryLiked에서 자기 좋아요 스킵 로직 제거 (서비스 레이어에서 차단되므로 불필요)
### Additional
- close #83 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 사용자가 자신의 스토리에 좋아요를 누르는 행동을 방지합니다.

* **개선 사항**
  * 알림 발송 시스템 로직이 개선되었습니다.
  * 스토리 좋아요 기능의 오류 처리가 강화되어 더 명확한 안내 메시지를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->