### PR TITLE
feat: 스토리 좋아요를 사진(시간대) 단위로 변경

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/notifications/dto/response/NotificationResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/dto/response/NotificationResponse.java
@@ -13,6 +13,7 @@ public record NotificationResponse(
         String senderProfileImageUrl,
         NotificationType type,
         Long referenceId,
+        String referenceType,
         boolean read,
         LocalDateTime createdAt
 ) {
@@ -28,6 +29,7 @@ public record NotificationResponse(
                 senderProfileImageUrl,
                 notification.getType(),
                 notification.getReferenceId(),
+                notification.getReferenceType(),
                 notification.isRead(),
                 notification.getCreatedAt()
         );

--- a/src/main/java/com/gbsw/snapy/domain/notifications/entity/Notification.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/entity/Notification.java
@@ -33,6 +33,9 @@ public class Notification {
     @Column(name = "reference_id")
     private Long referenceId;
 
+    @Column(name = "reference_type", length = 20)
+    private String referenceType;
+
     @Column(name = "is_read", nullable = false)
     private boolean read;
 

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
@@ -24,10 +24,11 @@ public class NotificationEventListener {
         try {
             notificationService.create(
                     event.ownerId(), event.senderId(),
-                    NotificationType.STORY_LIKE, event.storyId()
+                    NotificationType.STORY_LIKE, event.storyId(), event.type().name()
             );
         } catch (Exception e) {
-            log.warn("스토리 좋아요 알림 생성 실패 - storyId: {}", event.storyId(), e);
+            log.warn("스토리 좋아요 알림 생성 실패 - storyId: {}, type: {}",
+                    event.storyId(), event.type(), e);
         }
     }
 
@@ -36,7 +37,7 @@ public class NotificationEventListener {
         try {
             notificationService.create(
                     event.receiverId(), event.senderId(),
-                    NotificationType.FRIEND_REQUEST, event.requestId()
+                    NotificationType.FRIEND_REQUEST, event.requestId(), null
             );
         } catch (Exception e) {
             log.warn("친구 요청 알림 생성 실패 - requestId: {}", event.requestId(), e);
@@ -48,7 +49,7 @@ public class NotificationEventListener {
         try {
             notificationService.create(
                     event.senderId(), event.receiverId(),
-                    NotificationType.FRIEND_ACCEPTED, null
+                    NotificationType.FRIEND_ACCEPTED, null, null
             );
         } catch (Exception e) {
             log.warn("친구 수락 알림 생성 실패", e);
@@ -62,7 +63,7 @@ public class NotificationEventListener {
             try {
                 notificationService.create(
                         friendId, event.userId(),
-                        NotificationType.ALBUM_PUBLISHED, event.albumId()
+                        NotificationType.ALBUM_PUBLISHED, event.albumId(), null
                 );
             } catch (Exception e) {
                 log.warn("앨범 게시 알림 생성 실패 - albumId: {}, friendId: {}",
@@ -78,7 +79,7 @@ public class NotificationEventListener {
             try {
                 notificationService.create(
                         friendId, event.userId(),
-                        NotificationType.NEW_STORY, event.storyId()
+                        NotificationType.NEW_STORY, event.storyId(), null
                 );
             } catch (Exception e) {
                 log.warn("새 스토리 알림 생성 실패 - storyId: {}, friendId: {}",

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/StoryLikedEvent.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/StoryLikedEvent.java
@@ -1,4 +1,6 @@
 package com.gbsw.snapy.domain.notifications.event;
 
-public record StoryLikedEvent(Long storyId, Long senderId, Long ownerId) {
+import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
+
+public record StoryLikedEvent(Long storyId, Long senderId, Long ownerId, AlbumPhotoType type) {
 }

--- a/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
@@ -30,13 +30,15 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
 
-    public void create(Long receiverId, Long senderId, NotificationType type, Long referenceId) {
+    public void create(Long receiverId, Long senderId, NotificationType type,
+                       Long referenceId, String referenceType) {
         notificationRepository.save(
                 Notification.builder()
                         .receiverId(receiverId)
                         .senderId(senderId)
                         .type(type)
                         .referenceId(referenceId)
+                        .referenceType(referenceType)
                         .read(false)
                         .build()
         );

--- a/src/main/java/com/gbsw/snapy/domain/stories/controller/StoryController.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/controller/StoryController.java
@@ -1,5 +1,6 @@
 package com.gbsw.snapy.domain.stories.controller;
 
+import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
 import com.gbsw.snapy.domain.stories.dto.response.StoryDetailResponse;
 import com.gbsw.snapy.domain.stories.dto.response.StoryLikeListResponse;
 import com.gbsw.snapy.domain.stories.dto.response.StoryLikeResponse;
@@ -38,21 +39,23 @@ public class StoryController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @PostMapping("/{storyId}/likes")
+    @PostMapping("/{storyId}/photos/{type}/likes")
     public ResponseEntity<ApiResponse<StoryLikeResponse>> toggleLike(
             @PathVariable Long storyId,
+            @PathVariable AlbumPhotoType type,
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        StoryLikeResponse response = storyService.toggleLike(storyId, principal.getId());
+        StoryLikeResponse response = storyService.toggleLike(storyId, type, principal.getId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @GetMapping("/{storyId}/likes")
+    @GetMapping("/{storyId}/photos/{type}/likes")
     public ResponseEntity<ApiResponse<List<StoryLikeListResponse>>> getLikes(
             @PathVariable Long storyId,
+            @PathVariable AlbumPhotoType type,
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        List<StoryLikeListResponse> response = storyService.getLikes(storyId, principal.getId());
+        List<StoryLikeListResponse> response = storyService.getLikes(storyId, type, principal.getId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/stories/dto/response/StoryLikeResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/dto/response/StoryLikeResponse.java
@@ -1,7 +1,10 @@
 package com.gbsw.snapy.domain.stories.dto.response;
 
+import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
+
 public record StoryLikeResponse(
         Long storyId,
+        AlbumPhotoType type,
         boolean liked
 ) {
 }

--- a/src/main/java/com/gbsw/snapy/domain/stories/entity/StoryLike.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/entity/StoryLike.java
@@ -1,5 +1,6 @@
 package com.gbsw.snapy.domain.stories.entity;
 
+import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -7,7 +8,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "story_likes", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"story_id", "user_id"})
+        @UniqueConstraint(columnNames = {"story_id", "user_id", "type"})
 })
 @Getter
 @Builder
@@ -24,6 +25,10 @@ public class StoryLike {
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AlbumPhotoType type;
 
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryLikeRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryLikeRepository.java
@@ -1,5 +1,6 @@
 package com.gbsw.snapy.domain.stories.repository;
 
+import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
 import com.gbsw.snapy.domain.stories.entity.StoryLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,11 +9,9 @@ import java.util.Optional;
 
 public interface StoryLikeRepository extends JpaRepository<StoryLike, Long> {
 
-    Optional<StoryLike> findByStoryIdAndUserId(Long storyId, Long userId);
+    Optional<StoryLike> findByStoryIdAndUserIdAndType(Long storyId, Long userId, AlbumPhotoType type);
 
-    long countByStoryId(Long storyId);
-
-    boolean existsByStoryIdAndUserId(Long storyId, Long userId);
+    List<StoryLike> findByStoryIdAndTypeOrderByCreatedAtDesc(Long storyId, AlbumPhotoType type);
 
     List<StoryLike> findByStoryIdOrderByCreatedAtDesc(Long storyId);
 }

--- a/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryPhotoRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/repository/StoryPhotoRepository.java
@@ -1,5 +1,6 @@
 package com.gbsw.snapy.domain.stories.repository;
 
+import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
 import com.gbsw.snapy.domain.stories.entity.StoryPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,6 @@ public interface StoryPhotoRepository extends JpaRepository<StoryPhoto, Long> {
     List<StoryPhoto> findByStoryIdOrderByTypeAsc(Long storyId);
 
     List<StoryPhoto> findByStoryIdInOrderByTypeAsc(List<Long> storyIds);
+
+    boolean existsByStoryIdAndType(Long storyId, AlbumPhotoType type);
 }

--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -254,10 +254,6 @@ public class StoryService {
             throw new CustomException(ErrorCode.CANNOT_LIKE_OWN_STORY);
         }
 
-        if (!storyPhotoRepository.existsByStoryIdAndType(storyId, type)) {
-            throw new CustomException(ErrorCode.STORY_PHOTO_NOT_FOUND);
-        }
-
         Visibility feedVisibility = userSettingRepository.findById(ownerId)
                 .map(UserSetting::getFeedVisibility)
                 .orElse(Visibility.FRIENDS_ONLY);
@@ -271,6 +267,10 @@ public class StoryService {
             if (!isFriend) {
                 throw new CustomException(ErrorCode.ACCESS_DENIED);
             }
+        }
+
+        if (!storyPhotoRepository.existsByStoryIdAndType(storyId, type)) {
+            throw new CustomException(ErrorCode.STORY_PHOTO_NOT_FOUND);
         }
 
         Optional<StoryLike> existing = storyLikeRepository

--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -240,7 +240,7 @@ public class StoryService {
     }
 
     @Transactional
-    public StoryLikeResponse toggleLike(Long storyId, Long userId) {
+    public StoryLikeResponse toggleLike(Long storyId, AlbumPhotoType type, Long userId) {
         Story story = storyRepository.findById(storyId)
                 .orElseThrow(() -> new CustomException(ErrorCode.STORY_NOT_FOUND));
 
@@ -252,6 +252,10 @@ public class StoryService {
         Long ownerId = story.getUserId();
         if (ownerId.equals(userId)) {
             throw new CustomException(ErrorCode.CANNOT_LIKE_OWN_STORY);
+        }
+
+        if (!storyPhotoRepository.existsByStoryIdAndType(storyId, type)) {
+            throw new CustomException(ErrorCode.STORY_PHOTO_NOT_FOUND);
         }
 
         Visibility feedVisibility = userSettingRepository.findById(ownerId)
@@ -269,7 +273,8 @@ public class StoryService {
             }
         }
 
-        Optional<StoryLike> existing = storyLikeRepository.findByStoryIdAndUserId(storyId, userId);
+        Optional<StoryLike> existing = storyLikeRepository
+                .findByStoryIdAndUserIdAndType(storyId, userId, type);
 
         boolean liked;
         if (existing.isPresent()) {
@@ -280,18 +285,19 @@ public class StoryService {
                     StoryLike.builder()
                             .storyId(storyId)
                             .userId(userId)
+                            .type(type)
                             .build()
             );
             liked = true;
 
-            eventPublisher.publishEvent(new StoryLikedEvent(storyId, userId, ownerId));
+            eventPublisher.publishEvent(new StoryLikedEvent(storyId, userId, ownerId, type));
         }
 
-        return new StoryLikeResponse(storyId, liked);
+        return new StoryLikeResponse(storyId, type, liked);
     }
 
     @Transactional(readOnly = true)
-    public List<StoryLikeListResponse> getLikes(Long storyId, Long userId) {
+    public List<StoryLikeListResponse> getLikes(Long storyId, AlbumPhotoType type, Long userId) {
         Story story = storyRepository.findById(storyId)
                 .orElseThrow(() -> new CustomException(ErrorCode.STORY_NOT_FOUND));
 
@@ -299,7 +305,8 @@ public class StoryService {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
 
-        List<StoryLike> likes = storyLikeRepository.findByStoryIdOrderByCreatedAtDesc(storyId);
+        List<StoryLike> likes = storyLikeRepository
+                .findByStoryIdAndTypeOrderByCreatedAtDesc(storyId, type);
         if (likes.isEmpty()) {
             return List.of();
         }

--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -305,6 +305,10 @@ public class StoryService {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
 
+        if (!storyPhotoRepository.existsByStoryIdAndType(storyId, type)) {
+            throw new CustomException(ErrorCode.STORY_PHOTO_NOT_FOUND);
+        }
+
         List<StoryLike> likes = storyLikeRepository
                 .findByStoryIdAndTypeOrderByCreatedAtDesc(storyId, type);
         if (likes.isEmpty()) {

--- a/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
+++ b/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
     // Story
     STORY_NOT_FOUND(HttpStatus.NOT_FOUND, "스토리를 찾을 수 없습니다."),
     STORY_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 스토리입니다."),
+    STORY_PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 시간대의 스토리 사진을 찾을 수 없습니다."),
     CANNOT_LIKE_OWN_STORY(HttpStatus.BAD_REQUEST, "본인의 스토리에는 좋아요를 누를 수 없습니다."),
 
     // Notification


### PR DESCRIPTION
### Type of PR
- feat
### Changes
  - StoryLike 엔티티에 type(AlbumPhotoType) 컬럼 추가 및 유니크 제약 (story_id, user_id, type)으로 변경
  - StoryLikeRepository: findByStoryIdAndUserIdAndType, findByStoryIdAndTypeOrderByCreatedAtDesc 추가
  - StoryPhotoRepository.existsByStoryIdAndType 추가
  - StoryService.toggleLike/getLikes에 type 파라미터 추가, 대상 사진 존재 검증(STORY_PHOTO_NOT_FOUND)
  - StoryController: /api/stories/{storyId}/photos/{type}/likes로 엔드포인트 변경
  - Notification에 reference_type 컬럼 추가
  - NotificationService.create 시그니처에 referenceType 추가
  - StoryLikedEvent, StoryLikeResponse에 type 필드 포함
  - ErrorCode.STORY_PHOTO_NOT_FOUND (404) 추가
### Additional
- close #86 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 알림에 참조 유형 정보 추가
  * 스토리 좋아요를 사진 유형별로 구분하여 관리 가능

* **버그 수정**
  * 존재하지 않는 스토리 사진에 대한 오류 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->