### PR TITLE
feat: 데일리 앨범 publish 조건 완화 및 자정 자동 publish 배치 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 ### VS Code ###
 .vscode/
 /CLAUDE.md
+/.claude/settings.local.json

--- a/src/main/java/com/gbsw/snapy/SnapyApplication.java
+++ b/src/main/java/com/gbsw/snapy/SnapyApplication.java
@@ -2,8 +2,10 @@ package com.gbsw.snapy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class SnapyApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/gbsw/snapy/domain/albums/entity/DailyAlbum.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/entity/DailyAlbum.java
@@ -69,7 +69,7 @@ public class DailyAlbum {
             throw new IllegalArgumentException("증가값은 양수여야 합니다.");
         }
         if (this.photoCount + count > MAX_SET_COUNT) {
-            throw new IllegalStateException("앨범 세트 개수를 초과했습니다. (최대 " + MAX_SET_COUNT + "세트)");
+            throw new CustomException(ErrorCode.ALBUM_DAILY_LIMIT_EXCEEDED);
         }
         this.photoCount += count;
     }
@@ -77,9 +77,6 @@ public class DailyAlbum {
     public void publish() {
         if (this.status == AlbumStatus.PUBLISHED) {
             throw new CustomException(ErrorCode.ALBUM_ALREADY_PUBLISHED);
-        }
-        if (this.photoCount != MAX_SET_COUNT) {
-            throw new CustomException(ErrorCode.ALBUM_NOT_COMPLETED);
         }
         this.status = AlbumStatus.PUBLISHED;
         this.publishedAt = LocalDateTime.now(KST_ZONE);

--- a/src/main/java/com/gbsw/snapy/domain/albums/repository/DailyAlbumRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/repository/DailyAlbumRepository.java
@@ -1,5 +1,6 @@
 package com.gbsw.snapy.domain.albums.repository;
 
+import com.gbsw.snapy.domain.albums.entity.AlbumStatus;
 import com.gbsw.snapy.domain.albums.entity.DailyAlbum;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,4 +24,10 @@ public interface DailyAlbumRepository extends JpaRepository<DailyAlbum, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select a from DailyAlbum a where a.id = :id")
     Optional<DailyAlbum> findByIdForUpdate(@Param("id") Long id);
+
+    @Query("select a.id from DailyAlbum a where a.status = :status and a.albumDate < :date")
+    List<Long> findIdsByStatusAndAlbumDateBefore(
+            @Param("status") AlbumStatus status,
+            @Param("date") LocalDate date
+    );
 }

--- a/src/main/java/com/gbsw/snapy/domain/albums/scheduler/AlbumScheduler.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/scheduler/AlbumScheduler.java
@@ -1,0 +1,35 @@
+package com.gbsw.snapy.domain.albums.scheduler;
+
+import com.gbsw.snapy.domain.albums.service.AlbumService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AlbumScheduler {
+
+    private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final AlbumService albumService;
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void autoPublishDraftAlbums() {
+        LocalDate today = LocalDate.now(KST_ZONE);
+        List<Long> draftAlbumIds = albumService.findDraftAlbumIdsBefore(today);
+        log.info("[AlbumScheduler] 자동 publish 대상 앨범 수: {}", draftAlbumIds.size());
+        for (Long albumId : draftAlbumIds) {
+            try {
+                albumService.autoPublishOne(albumId);
+            } catch (Exception e) {
+                log.error("[AlbumScheduler] 앨범 자동 publish 실패 - albumId: {}", albumId, e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -20,6 +20,7 @@ import com.gbsw.snapy.domain.photos.service.PhotoService;
 import com.gbsw.snapy.global.exception.CustomException;
 import com.gbsw.snapy.global.exception.ErrorCode;
 import com.gbsw.snapy.domain.stories.entity.Story;
+import com.gbsw.snapy.domain.stories.repository.StoryPhotoRepository;
 import com.gbsw.snapy.domain.stories.repository.StoryRepository;
 import com.gbsw.snapy.domain.stories.service.StoryService;
 import com.gbsw.snapy.domain.friends.repository.FriendRepository;
@@ -62,6 +63,7 @@ public class AlbumService {
     private final S3Service s3Service;
     private final StoryService storyService;
     private final StoryRepository storyRepository;
+    private final StoryPhotoRepository storyPhotoRepository;
     private final UserSettingRepository userSettingRepository;
     private final FriendRepository friendRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -83,8 +85,17 @@ public class AlbumService {
                                 .build()
                 ));
 
-        if (albumPhotoRepository.existsByAlbumIdAndType(album.getId(), request.getType())) {
-            throw new CustomException(ErrorCode.DUPLICATE_ALBUM_PHOTO_TYPE);
+        boolean publishedAlready = album.getStatus() == AlbumStatus.PUBLISHED;
+        Optional<Story> existingStory = storyRepository.findByUserIdAndAlbumId(userId, album.getId());
+
+        if (publishedAlready && existingStory.isPresent()) {
+            if (storyPhotoRepository.existsByStoryIdAndType(existingStory.get().getId(), request.getType())) {
+                throw new CustomException(ErrorCode.DUPLICATE_ALBUM_PHOTO_TYPE);
+            }
+        } else {
+            if (albumPhotoRepository.existsByAlbumIdAndType(album.getId(), request.getType())) {
+                throw new CustomException(ErrorCode.DUPLICATE_ALBUM_PHOTO_TYPE);
+            }
         }
 
         album.increasePhotoCount(1);
@@ -108,25 +119,26 @@ public class AlbumService {
             }
         });
 
-        albumPhotoRepository.save(
-                AlbumPhoto.builder()
-                        .albumId(album.getId())
-                        .photoId(frontPhoto.photoId())
-                        .type(request.getType())
-                        .side(PhotoType.FRONT)
-                        .build()
-        );
+        if (!publishedAlready) {
+            albumPhotoRepository.save(
+                    AlbumPhoto.builder()
+                            .albumId(album.getId())
+                            .photoId(frontPhoto.photoId())
+                            .type(request.getType())
+                            .side(PhotoType.FRONT)
+                            .build()
+            );
 
-        albumPhotoRepository.save(
-                AlbumPhoto.builder()
-                        .albumId(album.getId())
-                        .photoId(backPhoto.photoId())
-                        .type(request.getType())
-                        .side(PhotoType.BACK)
-                        .build()
-        );
+            albumPhotoRepository.save(
+                    AlbumPhoto.builder()
+                            .albumId(album.getId())
+                            .photoId(backPhoto.photoId())
+                            .type(request.getType())
+                            .side(PhotoType.BACK)
+                            .build()
+            );
+        }
 
-        Optional<Story> existingStory = storyRepository.findByUserIdAndAlbumId(userId, album.getId());
         Story story;
         boolean storyCreated = false;
         if (existingStory.isPresent()) {
@@ -395,6 +407,25 @@ public class AlbumService {
         eventPublisher.publishEvent(new AlbumPublishedEvent(album.getId(), userId));
 
         return AlbumPublishResponse.from(album);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> findDraftAlbumIdsBefore(LocalDate date) {
+        return dailyAlbumRepository.findIdsByStatusAndAlbumDateBefore(AlbumStatus.DRAFT, date);
+    }
+
+    @Transactional
+    public void autoPublishOne(Long albumId) {
+        DailyAlbum album = dailyAlbumRepository.findByIdForUpdate(albumId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
+
+        if (album.getStatus() == AlbumStatus.PUBLISHED) {
+            return;
+        }
+
+        album.publish();
+
+        eventPublisher.publishEvent(new AlbumPublishedEvent(album.getId(), album.getUserId()));
     }
 
     @Transactional

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -98,7 +98,9 @@ public class AlbumService {
             }
         }
 
-        album.increasePhotoCount(1);
+        if (!publishedAlready) {
+            album.increasePhotoCount(1);
+        }
 
         PhotoUploadResponse frontPhoto = photoService.upload(request.getFrontImage(), userId, PhotoType.FRONT);
         PhotoUploadResponse backPhoto = photoService.upload(request.getBackImage(), userId, PhotoType.BACK);

--- a/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
+++ b/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
@@ -52,7 +52,7 @@ public enum ErrorCode {
     DUPLICATE_ALBUM_PHOTO_TYPE(HttpStatus.CONFLICT, "해당 시간대에 이미 사진이 등록되어 있습니다."),
     INVALID_ALBUM_PHOTO_TIME_SLOT(HttpStatus.BAD_REQUEST, "현재 시간대에 업로드할 수 없는 사진 타입입니다."),
     INVALID_MONTH(HttpStatus.BAD_REQUEST, "유효하지 않은 월입니다. (1~12)"),
-    ALBUM_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "5장을 모두 채운 후에 게시할 수 있습니다."),
+    ALBUM_DAILY_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "하루 업로드 한도(5장)를 초과했습니다."),
     ALBUM_ALREADY_PUBLISHED(HttpStatus.CONFLICT, "이미 게시된 앨범입니다."),
 
     // Story


### PR DESCRIPTION
### Type of PR
feat
### Changes
  - `DailyAlbum.publish()`에서 5장 충족 검증 제거 — 언제든 publish 가능하도록 변경
  - `DailyAlbum.increasePhotoCount` 초과 시 `IllegalStateException` → `CustomException(ALBUM_DAILY_LIMIT_EXCEEDED,
  409)`로 교체
  - `ErrorCode`에서 `ALBUM_NOT_COMPLETED` 제거, `ALBUM_DAILY_LIMIT_EXCEEDED` 추가
  - `AlbumService.upload()`: 이미 `PUBLISHED` 상태인 앨범이면 `AlbumPhoto` 저장을 스킵하고 Story에만 반영. 중복 체크도
  `StoryPhoto` 기준으로 전환
  - `@EnableScheduling` 추가 및 `AlbumScheduler` 신규 — KST 매일 00:00 cron으로 어제 이전 DRAFT 앨범을 자동 publish
  - 배치는 앨범별 `@Transactional` 메서드 호출(프록시 경유)로 건별 트랜잭션 분리, 실패는 로깅 후 다음 앨범 진행
### Additional
  - 하루 업로드 5장 총량 제한은 유지 (published 앨범에도 `photoCount`는 증가시킴)
  - 배치 publish 시에도 기존 `AlbumPublishedEvent`를 재사용하므로 친구 알림은 그대로 발행
  - 레이스 방지 위해 `autoPublishOne`은 `findByIdForUpdate` 락 + 이미 published면 no-op
  - close #88 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 매일 자정에 초안 상태의 앨범을 자동으로 발행하는 스케줄러 추가

* **개선 사항**
  * 앨범 발행 로직 개선: 사진 5장 모두 채우지 않아도 발행 가능하도록 변경
  * 발행된 앨범의 사진 관리 로직 최적화
  * 일일 업로드 한도 초과 시 에러 메시지 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->