### PR TITLE
feat: 사진 업로드 시간대 기준 변경 및 갭 시간대 FREE 슬롯 자동 폴백

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/entity/AlbumPhotoType.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/entity/AlbumPhotoType.java
@@ -4,19 +4,19 @@ public enum AlbumPhotoType {
     MORNING {
         @Override
         public boolean matches(int hour) {
-            return hour >= 6 && hour < 12;
+            return hour >= 6 && hour < 11;
         }
     },
     LUNCH {
         @Override
         public boolean matches(int hour) {
-            return hour >= 12 && hour < 18;
+            return hour >= 12 && hour < 16;
         }
     },
     DINNER {
         @Override
         public boolean matches(int hour) {
-            return hour < 6 || hour >= 18;
+            return hour >= 17 && hour < 24;
         }
     },
     FREE_1 {

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -72,9 +72,7 @@ public class AlbumService {
     @Transactional
     public AlbumUploadResponse upload(AlbumUploadRequest request, Long userId) {
         ZonedDateTime nowKst = ZonedDateTime.now(KST_ZONE);
-        if (!request.getType().matches(nowKst.getHour())) {
-            throw new CustomException(ErrorCode.INVALID_ALBUM_PHOTO_TIME_SLOT);
-        }
+        int hour = nowKst.getHour();
 
         LocalDate today = nowKst.toLocalDate();
         DailyAlbum album = dailyAlbumRepository.findByUserIdAndAlbumDate(userId, today)
@@ -88,12 +86,17 @@ public class AlbumService {
         boolean publishedAlready = album.getStatus() == AlbumStatus.PUBLISHED;
         Optional<Story> existingStory = storyRepository.findByUserIdAndAlbumId(userId, album.getId());
 
+        AlbumPhotoType resolvedType = request.getType();
+        if (!resolvedType.matches(hour)) {
+            resolvedType = findAvailableFreeSlot(album.getId(), publishedAlready, existingStory);
+        }
+
         if (publishedAlready && existingStory.isPresent()) {
-            if (storyPhotoRepository.existsByStoryIdAndType(existingStory.get().getId(), request.getType())) {
+            if (storyPhotoRepository.existsByStoryIdAndType(existingStory.get().getId(), resolvedType)) {
                 throw new CustomException(ErrorCode.DUPLICATE_ALBUM_PHOTO_TYPE);
             }
         } else {
-            if (albumPhotoRepository.existsByAlbumIdAndType(album.getId(), request.getType())) {
+            if (albumPhotoRepository.existsByAlbumIdAndType(album.getId(), resolvedType)) {
                 throw new CustomException(ErrorCode.DUPLICATE_ALBUM_PHOTO_TYPE);
             }
         }
@@ -126,7 +129,7 @@ public class AlbumService {
                     AlbumPhoto.builder()
                             .albumId(album.getId())
                             .photoId(frontPhoto.photoId())
-                            .type(request.getType())
+                            .type(resolvedType)
                             .side(PhotoType.FRONT)
                             .build()
             );
@@ -135,7 +138,7 @@ public class AlbumService {
                     AlbumPhoto.builder()
                             .albumId(album.getId())
                             .photoId(backPhoto.photoId())
-                            .type(request.getType())
+                            .type(resolvedType)
                             .side(PhotoType.BACK)
                             .build()
             );
@@ -154,13 +157,26 @@ public class AlbumService {
                         .orElseThrow(() -> e);
             }
         }
-        storyService.addPhotos(story.getId(), frontPhoto.photoId(), backPhoto.photoId(), request.getType());
+        storyService.addPhotos(story.getId(), frontPhoto.photoId(), backPhoto.photoId(), resolvedType);
 
         if (storyCreated) {
             eventPublisher.publishEvent(new NewStoryEvent(story.getId(), userId));
         }
 
-        return AlbumUploadResponse.from(album, request.getType());
+        return AlbumUploadResponse.from(album, resolvedType);
+    }
+
+    private AlbumPhotoType findAvailableFreeSlot(Long albumId, boolean publishedAlready,
+                                                 Optional<Story> existingStory) {
+        for (AlbumPhotoType free : List.of(AlbumPhotoType.FREE_1, AlbumPhotoType.FREE_2)) {
+            boolean taken = (publishedAlready && existingStory.isPresent())
+                    ? storyPhotoRepository.existsByStoryIdAndType(existingStory.get().getId(), free)
+                    : albumPhotoRepository.existsByAlbumIdAndType(albumId, free);
+            if (!taken) {
+                return free;
+            }
+        }
+        throw new CustomException(ErrorCode.INVALID_ALBUM_PHOTO_TIME_SLOT);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumService.java
@@ -83,6 +83,9 @@ public class AlbumService {
                                 .build()
                 ));
 
+        album = dailyAlbumRepository.findByIdForUpdate(album.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
+
         boolean publishedAlready = album.getStatus() == AlbumStatus.PUBLISHED;
         Optional<Story> existingStory = storyRepository.findByUserIdAndAlbumId(userId, album.getId());
 


### PR DESCRIPTION
### Type of PR
feat
### Changes
  - AlbumPhotoType 시간대 기준 변경: MORNING 6-11, LUNCH 12-16, DINNER 17-24
  - AlbumService.upload에서 요청 type이 현재 시간대와 불일치 시 FREE_1 → FREE_2 순으로 자동 폴백
  - findAvailableFreeSlot 헬퍼 추가 (published/draft 분기 모두 대응)
  - 응답/AlbumPhoto 저장/스토리 추가 시 resolvedType 사용
### Additional
  - 갭 시간대(0-6, 11-12, 16-17시)는 MORNING/LUNCH/DINNER 어디에도 속하지 않으므로 FREE 슬롯으로 자동 배정
  - FREE_1, FREE_2 모두 점유된 경우에만 INVALID_ALBUM_PHOTO_TIME_SLOT 발생
  - close #91 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 기능 개선 & 버그 수정

* **기능 개선**
  * 요청한 시간대가 현재 시간과 맞지 않을 경우 사용 가능한 슬롯에 자동으로 배치됨

* **버그 수정**
  * 앨범 사진 시간대 매칭 범위를 더 정확하게 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->