### PR TITLE
fix: publish 후 앨범 사진 업로드 시 데이터 유실 버그 수정

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/repository/AlbumPhotoRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/repository/AlbumPhotoRepository.java
@@ -6,6 +6,7 @@ import com.gbsw.snapy.domain.photos.entity.PhotoType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 
@@ -13,6 +14,8 @@ import java.util.List;
 public interface AlbumPhotoRepository extends JpaRepository<AlbumPhoto, Long> {
 
     List<AlbumPhoto> findByAlbumIdOrderByTypeAsc(Long albumId);
+
+    List<AlbumPhoto> findByAlbumIdAndCreatedAtLessThanEqualOrderByTypeAsc(Long albumId, LocalDateTime createdAt);
 
     boolean existsByAlbumIdAndType(Long albumId, AlbumPhotoType type);
 

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumCommandService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumCommandService.java
@@ -17,7 +17,6 @@ import com.gbsw.snapy.domain.photos.entity.PhotoType;
 import com.gbsw.snapy.domain.photos.repository.PhotoRepository;
 import com.gbsw.snapy.domain.photos.service.PhotoService;
 import com.gbsw.snapy.domain.stories.entity.Story;
-import com.gbsw.snapy.domain.stories.repository.StoryPhotoRepository;
 import com.gbsw.snapy.domain.stories.repository.StoryRepository;
 import com.gbsw.snapy.domain.stories.service.StoryService;
 import com.gbsw.snapy.global.exception.CustomException;
@@ -50,7 +49,6 @@ public class AlbumCommandService {
     private final S3Service s3Service;
     private final StoryService storyService;
     private final StoryRepository storyRepository;
-    private final StoryPhotoRepository storyPhotoRepository;
     private final ApplicationEventPublisher eventPublisher;
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
@@ -71,27 +69,16 @@ public class AlbumCommandService {
         album = dailyAlbumRepository.findByIdForUpdate(album.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
 
-        boolean publishedAlready = album.getStatus() == AlbumStatus.PUBLISHED;
-        Optional<Story> existingStory = storyRepository.findByUserIdAndAlbumId(userId, album.getId());
-
         AlbumPhotoType resolvedType = request.getType();
         if (!resolvedType.matches(hour)) {
-            resolvedType = findAvailableFreeSlot(album.getId(), publishedAlready, existingStory);
+            resolvedType = findAvailableFreeSlot(album.getId());
         }
 
-        if (publishedAlready && existingStory.isPresent()) {
-            if (storyPhotoRepository.existsByStoryIdAndType(existingStory.get().getId(), resolvedType)) {
-                throw new CustomException(ErrorCode.DUPLICATE_ALBUM_PHOTO_TYPE);
-            }
-        } else {
-            if (albumPhotoRepository.existsByAlbumIdAndType(album.getId(), resolvedType)) {
-                throw new CustomException(ErrorCode.DUPLICATE_ALBUM_PHOTO_TYPE);
-            }
+        if (albumPhotoRepository.existsByAlbumIdAndType(album.getId(), resolvedType)) {
+            throw new CustomException(ErrorCode.DUPLICATE_ALBUM_PHOTO_TYPE);
         }
 
-        if (!publishedAlready) {
-            album.increasePhotoCount(1);
-        }
+        album.increasePhotoCount(1);
 
         PhotoUploadResponse frontPhoto = photoService.upload(request.getFrontImage(), userId, PhotoType.FRONT);
         PhotoUploadResponse backPhoto = photoService.upload(request.getBackImage(), userId, PhotoType.BACK);
@@ -112,26 +99,25 @@ public class AlbumCommandService {
             }
         });
 
-        if (!publishedAlready) {
-            albumPhotoRepository.save(
-                    AlbumPhoto.builder()
-                            .albumId(album.getId())
-                            .photoId(frontPhoto.photoId())
-                            .type(resolvedType)
-                            .side(PhotoType.FRONT)
-                            .build()
-            );
+        albumPhotoRepository.save(
+                AlbumPhoto.builder()
+                        .albumId(album.getId())
+                        .photoId(frontPhoto.photoId())
+                        .type(resolvedType)
+                        .side(PhotoType.FRONT)
+                        .build()
+        );
 
-            albumPhotoRepository.save(
-                    AlbumPhoto.builder()
-                            .albumId(album.getId())
-                            .photoId(backPhoto.photoId())
-                            .type(resolvedType)
-                            .side(PhotoType.BACK)
-                            .build()
-            );
-        }
+        albumPhotoRepository.save(
+                AlbumPhoto.builder()
+                        .albumId(album.getId())
+                        .photoId(backPhoto.photoId())
+                        .type(resolvedType)
+                        .side(PhotoType.BACK)
+                        .build()
+        );
 
+        Optional<Story> existingStory = storyRepository.findByUserIdAndAlbumId(userId, album.getId());
         Story story;
         boolean storyCreated = false;
         if (existingStory.isPresent()) {
@@ -154,13 +140,9 @@ public class AlbumCommandService {
         return AlbumUploadResponse.from(album, resolvedType);
     }
 
-    private AlbumPhotoType findAvailableFreeSlot(Long albumId, boolean publishedAlready,
-                                                 Optional<Story> existingStory) {
+    private AlbumPhotoType findAvailableFreeSlot(Long albumId) {
         for (AlbumPhotoType free : List.of(AlbumPhotoType.FREE_1, AlbumPhotoType.FREE_2)) {
-            boolean taken = (publishedAlready && existingStory.isPresent())
-                    ? storyPhotoRepository.existsByStoryIdAndType(existingStory.get().getId(), free)
-                    : albumPhotoRepository.existsByAlbumIdAndType(albumId, free);
-            if (!taken) {
+            if (!albumPhotoRepository.existsByAlbumIdAndType(albumId, free)) {
                 return free;
             }
         }

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
@@ -52,7 +52,7 @@ public class AlbumQueryService {
             return null;
         }
 
-        List<PhotoSetView> sets = loadPhotoSets(album.getId());
+        List<PhotoSetView> sets = loadPhotoSets(album.getId(), null);
         List<AlbumTodayResponse.AlbumPhotoSet> mapped = sets.stream()
                 .map(s -> new AlbumTodayResponse.AlbumPhotoSet(s.type(), s.frontImageUrl(), s.backImageUrl(), s.createdAt()))
                 .toList();
@@ -75,23 +75,21 @@ public class AlbumQueryService {
 
             UserSetting setting = userSettingRepository.findById(album.getUserId()).orElse(null);
 
+            Visibility v;
             if (isCurrentMonth) {
-                Visibility v = (setting != null) ? setting.getFeedVisibility() : Visibility.FRIENDS_ONLY;
-                if (v == Visibility.FRIENDS_ONLY && !friendRepository.existsFriendship(userId, album.getUserId())) {
-                    throw new CustomException(ErrorCode.ACCESS_DENIED);
-                }
+                v = (setting != null) ? setting.getFeedVisibility() : Visibility.FRIENDS_ONLY;
             } else {
-                Visibility v = (setting != null) ? setting.getPastAlbumVisibility() : Visibility.FRIENDS_ONLY;
+                v = (setting != null) ? setting.getPastAlbumVisibility() : Visibility.FRIENDS_ONLY;
                 if (v == Visibility.ONLY_ME) {
                     throw new CustomException(ErrorCode.ACCESS_DENIED);
                 }
-                if (v == Visibility.FRIENDS_ONLY && !friendRepository.existsFriendship(userId, album.getUserId())) {
-                    throw new CustomException(ErrorCode.ACCESS_DENIED);
-                }
+            }
+            if (v == Visibility.FRIENDS_ONLY && !friendRepository.existsFriendship(userId, album.getUserId())) {
+                throw new CustomException(ErrorCode.ACCESS_DENIED);
             }
         }
 
-        List<PhotoSetView> sets = loadPhotoSets(album.getId());
+        List<PhotoSetView> sets = loadPhotoSets(album.getId(), album.getPublishedAt());
         List<AlbumDetailResponse.AlbumPhotoSet> mapped = sets.stream()
                 .map(s -> new AlbumDetailResponse.AlbumPhotoSet(s.type(), s.frontImageUrl(), s.backImageUrl(), s.createdAt()))
                 .toList();
@@ -198,8 +196,10 @@ public class AlbumQueryService {
         return result;
     }
 
-    private List<PhotoSetView> loadPhotoSets(Long albumId) {
-        List<AlbumPhoto> albumPhotos = albumPhotoRepository.findByAlbumIdOrderByTypeAsc(albumId);
+    private List<PhotoSetView> loadPhotoSets(Long albumId, LocalDateTime snapshotBoundary) {
+        List<AlbumPhoto> albumPhotos = (snapshotBoundary == null)
+                ? albumPhotoRepository.findByAlbumIdOrderByTypeAsc(albumId)
+                : albumPhotoRepository.findByAlbumIdAndCreatedAtLessThanEqualOrderByTypeAsc(albumId, snapshotBoundary);
         if (albumPhotos.isEmpty()) {
             return List.of();
         }

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
@@ -89,7 +89,8 @@ public class AlbumQueryService {
             }
         }
 
-        List<PhotoSetView> sets = loadPhotoSets(album.getId(), album.getPublishedAt());
+        LocalDateTime snapshotBoundary = album.getUserId().equals(userId) ? null : album.getPublishedAt();
+        List<PhotoSetView> sets = loadPhotoSets(album.getId(), snapshotBoundary);
         List<AlbumDetailResponse.AlbumPhotoSet> mapped = sets.stream()
                 .map(s -> new AlbumDetailResponse.AlbumPhotoSet(s.type(), s.frontImageUrl(), s.backImageUrl(), s.createdAt()))
                 .toList();


### PR DESCRIPTION
### Type of PR
fix
### Changes
  - AlbumCommandService.upload의 publishedAlready 분기 제거 — publish 여부와 무관하게 항상 album_photo 저장, hoto_count 증가, 동일 슬롯 중복 체크
  - findAvailableFreeSlot을 album_photo 단일 기준으로 단순화 (StoryPhotoRepository 의존성 제거)
  - AlbumPhotoRepository에 스냅샷 조회 메서드 findByAlbumIdAndCreatedAtLessThanEqualOrderByTypeAsc 추가
  - AlbumQueryService.getAlbumDetail은 album.published_at 기준 스냅샷 필터 적용 (DRAFT면 전체)
  - AlbumQueryService.getTodayAlbum은 publish 여부 무관 전체 반환
### Additional
  - 하루 5개(MAX_SET_COUNT) 제한은 publish 이후 업로드도 포함해 그대로 적용
  - story_photo는 친구 피드용으로 유지, 자정 배치가 계속 정리
  - 배포 환경에서 백필 SQL 수동 실행 예정 (기존 publish 후 업로드분을 album_photo로 복구)
  - close #96 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 앨범 사진 검색 시 생성 날짜 기준 필터링 개선
  * 중복 사진 확인 로직 단순화 및 안정성 강화

* **리팩토링**
  * 앨범 사진 관리 시스템 내부 구조 최적화
  * 불필요한 의존성 제거 및 코드 효율성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->