### PR TITLE
feat: 스토리 목록에 본인 스토리 포함 및 최상단 노출

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/stories/service/StoryService.java
@@ -90,13 +90,12 @@ public class StoryService {
     @Transactional(readOnly = true)
     public List<StoryListResponse> getStories(Long userId) {
         List<Long> friendIds = friendRepository.findFriendIdsByUserId(userId);
-        if (friendIds.isEmpty()) {
-            return List.of();
-        }
+        List<Long> targetIds = new ArrayList<>(friendIds);
+        targetIds.add(userId);
 
         LocalDateTime nowKst = LocalDateTime.now(KST_ZONE);
         List<Story> stories = storyRepository
-                .findByUserIdInAndExpiresAtAfterOrderByCreatedAtDesc(friendIds, nowKst);
+                .findByUserIdInAndExpiresAtAfterOrderByCreatedAtDesc(targetIds, nowKst);
 
         if (stories.isEmpty()) {
             return List.of();
@@ -108,7 +107,14 @@ public class StoryService {
                 .collect(Collectors.toMap(UserSetting::getUserId, UserSetting::getFeedVisibility));
 
         stories = stories.stream()
-                .filter(story -> visibilityMap.getOrDefault(story.getUserId(), Visibility.FRIENDS_ONLY) != Visibility.ONLY_ME)
+                .filter(story -> story.getUserId().equals(userId)
+                        || visibilityMap.getOrDefault(story.getUserId(), Visibility.FRIENDS_ONLY) != Visibility.ONLY_ME)
+                .sorted((a, b) -> {
+                    boolean aOwn = a.getUserId().equals(userId);
+                    boolean bOwn = b.getUserId().equals(userId);
+                    if (aOwn != bOwn) return aOwn ? -1 : 1;
+                    return b.getCreatedAt().compareTo(a.getCreatedAt());
+                })
                 .toList();
 
         if (stories.isEmpty()) {


### PR DESCRIPTION
### Type of PR
feat
### Changes
   -  StoryService.getStories에서 조회 대상에 본인 userId 추가
   - 친구 없을 때 early return 제거 (본인 스토리는 노출되어야 함)
   - visibility 필터에서 본인은 예외 처리 (ONLY_ME여도 자기 스토리는 보임)
   - 본인 스토리를 최상단에 정렬, 그 외는 createdAt DESC
### Additional
- 본인은 하루 1개 스토리만 생성되므로 최상단에는 1건만 노출됨
- close #102 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자가 피드에서 자신의 스토리를 볼 수 있게 됨
  * 사용자의 스토리가 피드 상단에 우선적으로 표시됨
  * 스토리들이 생성 날짜 순으로 정렬되어 표시됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->