### PR TITLE
refactor: loadPhotoSets & PhotoSetView public으로 변경

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
@@ -197,7 +197,7 @@ public class AlbumQueryService {
         return result;
     }
 
-    private List<PhotoSetView> loadPhotoSets(Long albumId, LocalDateTime snapshotBoundary) {
+    public List<PhotoSetView> loadPhotoSets(Long albumId, LocalDateTime snapshotBoundary) {
         List<AlbumPhoto> albumPhotos = (snapshotBoundary == null)
                 ? albumPhotoRepository.findByAlbumIdOrderByTypeAsc(albumId)
                 : albumPhotoRepository.findByAlbumIdAndCreatedAtLessThanEqualOrderByTypeAsc(albumId, snapshotBoundary);
@@ -237,7 +237,7 @@ public class AlbumQueryService {
         return sets;
     }
 
-    private record PhotoSetView(AlbumPhotoType type, String frontImageUrl, String backImageUrl,
+    public record PhotoSetView(AlbumPhotoType type, String frontImageUrl, String backImageUrl,
                                 LocalDateTime createdAt) {
     }
 }


### PR DESCRIPTION
### Type of PR
refactor

### Changes
- AlbumQueryService.loadPhotoSets: private → public으로 변경
- AlbumQueryService.PhotoSetView: private record → public record로 변경

### Additional

close #112 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 앨범 서비스의 내부 기능을 공개 인터페이스로 노출하여 외부 컴포넌트에서의 접근성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->