### PR TITLE
fix: 알림 생성 트랜잭션 누락 수정

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/scheduler/AlbumScheduler.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/scheduler/AlbumScheduler.java
@@ -1,6 +1,10 @@
 package com.gbsw.snapy.domain.albums.scheduler;
 
+import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
 import com.gbsw.snapy.domain.albums.service.AlbumCommandService;
+import com.gbsw.snapy.domain.notifications.entity.NotificationType;
+import com.gbsw.snapy.domain.notifications.service.NotificationService;
+import com.gbsw.snapy.domain.users.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -18,6 +22,8 @@ public class AlbumScheduler {
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
     private final AlbumCommandService albumCommandService;
+    private final NotificationService notificationService;
+    private final UserRepository userRepository;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void autoPublishDraftAlbums() {
@@ -29,6 +35,36 @@ public class AlbumScheduler {
                 albumCommandService.autoPublishOne(albumId);
             } catch (Exception e) {
                 log.error("[AlbumScheduler] 앨범 자동 publish 실패 - albumId: {}", albumId, e);
+            }
+        }
+    }
+
+    @Scheduled(cron = "0 0 6 * * *", zone = "Asia/Seoul")
+    public void remindMorningPhotoUpload() {
+        createPhotoUploadReminders(AlbumPhotoType.MORNING);
+    }
+
+    @Scheduled(cron = "0 0 12 * * *", zone = "Asia/Seoul")
+    public void remindLunchPhotoUpload() {
+        createPhotoUploadReminders(AlbumPhotoType.LUNCH);
+    }
+
+    @Scheduled(cron = "0 0 17 * * *", zone = "Asia/Seoul")
+    public void remindDinnerPhotoUpload() {
+        createPhotoUploadReminders(AlbumPhotoType.DINNER);
+    }
+
+    private void createPhotoUploadReminders(AlbumPhotoType type) {
+        List<Long> userIds = userRepository.findAllIds();
+        log.info("[AlbumScheduler] 사진 업로드 리마인더 생성 - type: {}, userCount: {}", type, userIds.size());
+        for (Long userId : userIds) {
+            try {
+                notificationService.create(
+                        userId, userId,
+                        NotificationType.ALBUM_PHOTO_UPLOAD_REMINDER, null, type.name()
+                );
+            } catch (Exception e) {
+                log.warn("[AlbumScheduler] 사진 업로드 리마인더 생성 실패 - userId: {}, type: {}", userId, type, e);
             }
         }
     }

--- a/src/main/java/com/gbsw/snapy/domain/comments/service/CommentService.java
+++ b/src/main/java/com/gbsw/snapy/domain/comments/service/CommentService.java
@@ -14,6 +14,7 @@ import com.gbsw.snapy.domain.comments.entity.Comment;
 import com.gbsw.snapy.domain.comments.entity.CommentAttachment;
 import com.gbsw.snapy.domain.comments.repository.CommentAttachmentRepository;
 import com.gbsw.snapy.domain.comments.repository.CommentRepository;
+import com.gbsw.snapy.domain.notifications.event.FeedCommentEvent;
 import com.gbsw.snapy.domain.photos.dto.response.PhotoUploadResponse;
 import com.gbsw.snapy.domain.photos.entity.Photo;
 import com.gbsw.snapy.domain.photos.entity.PhotoType;
@@ -25,6 +26,7 @@ import com.gbsw.snapy.global.exception.CustomException;
 import com.gbsw.snapy.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,6 +46,7 @@ public class CommentService {
     private final DailyAlbumRepository dailyAlbumRepository;
     private final PhotoRepository photoRepository;
     private final AudioRepository audioRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public CommentUploadResponse upload(Long albumId, Long userId, CommentUploadRequest request) {
@@ -88,6 +91,11 @@ public class CommentService {
                         .attachment(savedAttachment)
                         .build()
         );
+
+        if (!album.getUserId().equals(userId)) {
+            eventPublisher.publishEvent(new FeedCommentEvent(
+                    comment.getId(), album.getId(), userId, album.getUserId()));
+        }
 
         return CommentUploadResponse.from(comment);
     }

--- a/src/main/java/com/gbsw/snapy/domain/notifications/entity/NotificationType.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/entity/NotificationType.java
@@ -1,9 +1,12 @@
 package com.gbsw.snapy.domain.notifications.entity;
 
 public enum NotificationType {
+    ALBUM_PHOTO_UPLOAD_REMINDER,
     STORY_LIKE,
     FRIEND_REQUEST,
     FRIEND_ACCEPTED,
     ALBUM_PUBLISHED,
-    NEW_STORY
+    NEW_STORY,
+    FEED_COMMENT,
+    GUESTBOOK_CREATED
 }

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/FeedCommentEvent.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/FeedCommentEvent.java
@@ -1,0 +1,4 @@
+package com.gbsw.snapy.domain.notifications.event;
+
+public record FeedCommentEvent(Long commentId, Long albumId, Long senderId, Long ownerId) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/GuestbookCreatedEvent.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/GuestbookCreatedEvent.java
@@ -1,0 +1,4 @@
+package com.gbsw.snapy.domain.notifications.event;
+
+public record GuestbookCreatedEvent(Long guestbookId, Long senderId, Long ownerId) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
@@ -33,6 +33,31 @@ public class NotificationEventListener {
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFeedComment(FeedCommentEvent event) {
+        try {
+            notificationService.create(
+                    event.ownerId(), event.senderId(),
+                    NotificationType.FEED_COMMENT, event.commentId(), String.valueOf(event.albumId())
+            );
+        } catch (Exception e) {
+            log.warn("피드 댓글 알림 생성 실패 - commentId: {}, albumId: {}",
+                    event.commentId(), event.albumId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleGuestbookCreated(GuestbookCreatedEvent event) {
+        try {
+            notificationService.create(
+                    event.ownerId(), event.senderId(),
+                    NotificationType.GUESTBOOK_CREATED, event.guestbookId(), null
+            );
+        } catch (Exception e) {
+            log.warn("방명록 알림 생성 실패 - guestbookId: {}", event.guestbookId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleFriendRequest(FriendRequestEvent event) {
         try {
             notificationService.create(

--- a/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -30,6 +31,7 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void create(Long receiverId, Long senderId, NotificationType type,
                        Long referenceId, String referenceType) {
         notificationRepository.save(

--- a/src/main/java/com/gbsw/snapy/domain/users/repository/UserRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/users/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.gbsw.snapy.domain.users.repository;
 
 import com.gbsw.snapy.domain.users.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -17,4 +18,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByHandle(String handle);
     List<User> findTop10ByPhoneIn(List<String> phones);
     List<User> findByHandleContainingIgnoreCaseOrUsernameContainingIgnoreCase(String handle, String username);
+
+    @Query("select u.id from User u")
+    List<Long> findAllIds();
 }


### PR DESCRIPTION
### Type of PR
fix
### Changes
- NotificationService.create에 REQUIRES_NEW 트랜잭션 추가
- AFTER_COMMIT 이벤트 리스너에서 알림 저장이 별도 트랜잭션으로 커밋되도록 수정
### Additional
- 알림 이벤트 발행 로직은 유지하고 저장 트랜잭션 범위만 최소 수정
- 방명록 도메인은 아직 없어 이벤트/리스너만 준비
- 기존 sender_id NOT NULL 스키마에 맞춰 리마인더 알림 senderId는 수신자 본인으로 저장
- close #107 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사진 업로드 리마인더 알림 추가 (매일 아침 6시, 점심 12시, 저녁 5시)
  * 피드 댓글 알림 기능 구현
  * 방명록 생성 알림 추가
  * 알림 시스템 확장으로 더 나은 사용자 경험 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->