### PR TITLE
refactor: 월별 앨범 조회 대상 파라미터를 handle로 변경

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/controller/AlbumController.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/controller/AlbumController.java
@@ -38,11 +38,10 @@ public class AlbumController {
     @GetMapping
     public ResponseEntity<ApiResponse<List<AlbumListResponse>>> getAlbumsByMonth(
             @RequestParam int month,
-            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) String userHandle,
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        Long targetUserId = (userId != null) ? userId : principal.getId();
-        List<AlbumListResponse> response = albumQueryService.getAlbumsByMonth(targetUserId, month, principal.getId());
+        List<AlbumListResponse> response = albumQueryService.getAlbumsByMonth(userHandle, month, principal.getId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
@@ -105,9 +105,11 @@ public class AlbumQueryService {
             throw new CustomException(ErrorCode.INVALID_MONTH);
         }
 
-        Long targetUserId = (targetUserHandle == null || targetUserHandle.isBlank())
+        String normalizedHandle = (targetUserHandle == null) ? null : targetUserHandle.trim();
+
+        Long targetUserId = (normalizedHandle == null || normalizedHandle.isBlank())
                 ? requesterId
-                : userRepository.findByHandle(targetUserHandle)
+                : userRepository.findByHandle(normalizedHandle)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND))
                 .getId();
 

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
@@ -16,6 +16,7 @@ import com.gbsw.snapy.domain.photos.repository.PhotoRepository;
 import com.gbsw.snapy.domain.settings.entity.UserSetting;
 import com.gbsw.snapy.domain.settings.entity.Visibility;
 import com.gbsw.snapy.domain.settings.repository.UserSettingRepository;
+import com.gbsw.snapy.domain.users.repository.UserRepository;
 import com.gbsw.snapy.global.exception.CustomException;
 import com.gbsw.snapy.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,7 @@ public class AlbumQueryService {
     private final PhotoRepository photoRepository;
     private final UserSettingRepository userSettingRepository;
     private final FriendRepository friendRepository;
+    private final UserRepository userRepository;
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
     @Transactional(readOnly = true)
@@ -98,10 +100,16 @@ public class AlbumQueryService {
     }
 
     @Transactional(readOnly = true)
-    public List<AlbumListResponse> getAlbumsByMonth(Long targetUserId, int month, Long requesterId) {
+    public List<AlbumListResponse> getAlbumsByMonth(String targetUserHandle, int month, Long requesterId) {
         if (month < 1 || month > 12) {
             throw new CustomException(ErrorCode.INVALID_MONTH);
         }
+
+        Long targetUserId = (targetUserHandle == null || targetUserHandle.isBlank())
+                ? requesterId
+                : userRepository.findByHandle(targetUserHandle)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND))
+                .getId();
 
         boolean isOwner = targetUserId.equals(requesterId);
         YearMonth currentMonth = YearMonth.now(KST_ZONE);


### PR DESCRIPTION
### Type of PR
refactor
### Changes
- getAlbumsByMonth API의 조회 대상 파라미터를 userId에서 userHandle로 변경
- userHandle이 없으면 기존처럼 인증된 사용자 본인 앨범 조회
- userHandle이 있으면 UserRepository에서 사용자 ID를 조회한 뒤 기존 공개 범위 검증 로직 적용
### Additional
- close #126 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 월별 앨범 조회 기능이 개선되었습니다. 이제 사용자 ID 대신 사용자 핸들을 통해 앨범을 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->