### PR TITLE
feat:  데일리 앨범 좋아요 추가

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/controller/AlbumController.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/controller/AlbumController.java
@@ -2,6 +2,7 @@ package com.gbsw.snapy.domain.albums.controller;
 
 import com.gbsw.snapy.domain.albums.dto.request.AlbumUploadRequest;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumDetailResponse;
+import com.gbsw.snapy.domain.albums.dto.response.AlbumLikeResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumListResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumPublishResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumTodayResponse;
@@ -76,6 +77,15 @@ public class AlbumController {
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
         AlbumPublishResponse response = albumCommandService.publishAlbum(albumId, principal.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/{albumId}/likes")
+    public ResponseEntity<ApiResponse<AlbumLikeResponse>> toggleLike(
+            @PathVariable Long albumId,
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        AlbumLikeResponse response = albumCommandService.toggleLike(albumId, principal.getId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/albums/dto/response/AlbumDetailResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/dto/response/AlbumDetailResponse.java
@@ -11,13 +11,17 @@ public record AlbumDetailResponse(
         Long albumId,
         LocalDate albumDate,
         int photoCount,
+        long likeCount,
+        boolean liked,
         List<AlbumPhotoSet> photos
 ) {
-    public static AlbumDetailResponse of(DailyAlbum album, List<AlbumPhotoSet> photos) {
+    public static AlbumDetailResponse of(DailyAlbum album, long likeCount, boolean liked, List<AlbumPhotoSet> photos) {
         return new AlbumDetailResponse(
                 album.getId(),
                 album.getAlbumDate(),
                 album.getPhotoCount(),
+                likeCount,
+                liked,
                 photos
         );
     }

--- a/src/main/java/com/gbsw/snapy/domain/albums/dto/response/AlbumLikeResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/dto/response/AlbumLikeResponse.java
@@ -1,0 +1,8 @@
+package com.gbsw.snapy.domain.albums.dto.response;
+
+public record AlbumLikeResponse(
+        Long albumId,
+        boolean liked,
+        long likeCount
+) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/albums/entity/DailyAlbumLike.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/entity/DailyAlbumLike.java
@@ -1,0 +1,39 @@
+package com.gbsw.snapy.domain.albums.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "daily_album_likes", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"album_id", "user_id"})
+})
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class DailyAlbumLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "album_id", nullable = false)
+    private Long albumId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/gbsw/snapy/domain/albums/repository/DailyAlbumLikeRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/repository/DailyAlbumLikeRepository.java
@@ -1,0 +1,23 @@
+package com.gbsw.snapy.domain.albums.repository;
+
+import com.gbsw.snapy.domain.albums.entity.DailyAlbumLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DailyAlbumLikeRepository extends JpaRepository<DailyAlbumLike, Long> {
+
+    Optional<DailyAlbumLike> findByAlbumIdAndUserId(Long albumId, Long userId);
+
+    long countByAlbumId(Long albumId);
+
+    boolean existsByAlbumIdAndUserId(Long albumId, Long userId);
+
+    List<DailyAlbumLike> findByAlbumIdInAndUserId(Collection<Long> albumIds, Long userId);
+
+    List<DailyAlbumLike> findByAlbumIdIn(Collection<Long> albumIds);
+}

--- a/src/main/java/com/gbsw/snapy/domain/albums/repository/DailyAlbumLikeRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/repository/DailyAlbumLikeRepository.java
@@ -2,6 +2,8 @@ package com.gbsw.snapy.domain.albums.repository;
 
 import com.gbsw.snapy.domain.albums.entity.DailyAlbumLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
@@ -19,5 +21,12 @@ public interface DailyAlbumLikeRepository extends JpaRepository<DailyAlbumLike, 
 
     List<DailyAlbumLike> findByAlbumIdInAndUserId(Collection<Long> albumIds, Long userId);
 
-    List<DailyAlbumLike> findByAlbumIdIn(Collection<Long> albumIds);
+    @Query("SELECT l.albumId AS albumId, COUNT(l) AS count " +
+            "FROM DailyAlbumLike l WHERE l.albumId IN :albumIds GROUP BY l.albumId")
+    List<AlbumLikeCountProjection> countByAlbumIdIn(@Param("albumIds") Collection<Long> albumIds);
+
+    interface AlbumLikeCountProjection {
+        Long getAlbumId();
+        Long getCount();
+    }
 }

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumCommandService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumCommandService.java
@@ -1,16 +1,23 @@
 package com.gbsw.snapy.domain.albums.service;
 
 import com.gbsw.snapy.domain.albums.dto.request.AlbumUploadRequest;
+import com.gbsw.snapy.domain.albums.dto.response.AlbumLikeResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumPublishResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumUploadResponse;
 import com.gbsw.snapy.domain.albums.entity.AlbumPhoto;
 import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
 import com.gbsw.snapy.domain.albums.entity.AlbumStatus;
 import com.gbsw.snapy.domain.albums.entity.DailyAlbum;
+import com.gbsw.snapy.domain.albums.entity.DailyAlbumLike;
 import com.gbsw.snapy.domain.albums.repository.AlbumPhotoRepository;
+import com.gbsw.snapy.domain.albums.repository.DailyAlbumLikeRepository;
 import com.gbsw.snapy.domain.albums.repository.DailyAlbumRepository;
+import com.gbsw.snapy.domain.friends.repository.FriendRepository;
 import com.gbsw.snapy.domain.notifications.event.AlbumPublishedEvent;
 import com.gbsw.snapy.domain.notifications.event.NewStoryEvent;
+import com.gbsw.snapy.domain.settings.entity.UserSetting;
+import com.gbsw.snapy.domain.settings.entity.Visibility;
+import com.gbsw.snapy.domain.settings.repository.UserSettingRepository;
 import com.gbsw.snapy.domain.photos.dto.response.PhotoUploadResponse;
 import com.gbsw.snapy.domain.photos.entity.Photo;
 import com.gbsw.snapy.domain.photos.entity.PhotoType;
@@ -32,6 +39,7 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -44,11 +52,14 @@ public class AlbumCommandService {
 
     private final DailyAlbumRepository dailyAlbumRepository;
     private final AlbumPhotoRepository albumPhotoRepository;
+    private final DailyAlbumLikeRepository dailyAlbumLikeRepository;
     private final PhotoService photoService;
     private final PhotoRepository photoRepository;
     private final S3Service s3Service;
     private final StoryService storyService;
     private final StoryRepository storyRepository;
+    private final UserSettingRepository userSettingRepository;
+    private final FriendRepository friendRepository;
     private final ApplicationEventPublisher eventPublisher;
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
@@ -182,6 +193,56 @@ public class AlbumCommandService {
         album.publish();
 
         eventPublisher.publishEvent(new AlbumPublishedEvent(album.getId(), album.getUserId()));
+    }
+
+    @Transactional
+    public AlbumLikeResponse toggleLike(Long albumId, Long userId) {
+        DailyAlbum album = dailyAlbumRepository.findById(albumId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
+
+        if (!album.getUserId().equals(userId)) {
+            if (album.getStatus() != AlbumStatus.PUBLISHED) {
+                throw new CustomException(ErrorCode.ACCESS_DENIED);
+            }
+
+            YearMonth albumMonth = YearMonth.from(album.getAlbumDate());
+            YearMonth currentMonth = YearMonth.now(KST_ZONE);
+            boolean isCurrentMonth = albumMonth.equals(currentMonth);
+
+            UserSetting setting = userSettingRepository.findById(album.getUserId()).orElse(null);
+
+            Visibility v;
+            if (isCurrentMonth) {
+                v = (setting != null) ? setting.getFeedVisibility() : Visibility.FRIENDS_ONLY;
+            } else {
+                v = (setting != null) ? setting.getPastAlbumVisibility() : Visibility.FRIENDS_ONLY;
+                if (v == Visibility.ONLY_ME) {
+                    throw new CustomException(ErrorCode.ACCESS_DENIED);
+                }
+            }
+            if (v == Visibility.FRIENDS_ONLY && !friendRepository.existsFriendship(userId, album.getUserId())) {
+                throw new CustomException(ErrorCode.ACCESS_DENIED);
+            }
+        }
+
+        Optional<DailyAlbumLike> existing = dailyAlbumLikeRepository.findByAlbumIdAndUserId(albumId, userId);
+
+        boolean liked;
+        if (existing.isPresent()) {
+            dailyAlbumLikeRepository.delete(existing.get());
+            liked = false;
+        } else {
+            dailyAlbumLikeRepository.save(
+                    DailyAlbumLike.builder()
+                            .albumId(albumId)
+                            .userId(userId)
+                            .build()
+            );
+            liked = true;
+        }
+
+        long likeCount = dailyAlbumLikeRepository.countByAlbumId(albumId);
+        return new AlbumLikeResponse(albumId, liked, likeCount);
     }
 
     @Transactional

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
@@ -8,6 +8,7 @@ import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
 import com.gbsw.snapy.domain.albums.entity.AlbumStatus;
 import com.gbsw.snapy.domain.albums.entity.DailyAlbum;
 import com.gbsw.snapy.domain.albums.repository.AlbumPhotoRepository;
+import com.gbsw.snapy.domain.albums.repository.DailyAlbumLikeRepository;
 import com.gbsw.snapy.domain.albums.repository.DailyAlbumRepository;
 import com.gbsw.snapy.domain.friends.repository.FriendRepository;
 import com.gbsw.snapy.domain.photos.entity.Photo;
@@ -39,6 +40,7 @@ public class AlbumQueryService {
 
     private final DailyAlbumRepository dailyAlbumRepository;
     private final AlbumPhotoRepository albumPhotoRepository;
+    private final DailyAlbumLikeRepository dailyAlbumLikeRepository;
     private final PhotoRepository photoRepository;
     private final UserSettingRepository userSettingRepository;
     private final FriendRepository friendRepository;
@@ -96,7 +98,10 @@ public class AlbumQueryService {
         List<AlbumDetailResponse.AlbumPhotoSet> mapped = sets.stream()
                 .map(s -> new AlbumDetailResponse.AlbumPhotoSet(s.type(), s.frontImageUrl(), s.backImageUrl(), s.createdAt()))
                 .toList();
-        return AlbumDetailResponse.of(album, mapped);
+
+        long likeCount = dailyAlbumLikeRepository.countByAlbumId(album.getId());
+        boolean liked = dailyAlbumLikeRepository.existsByAlbumIdAndUserId(album.getId(), userId);
+        return AlbumDetailResponse.of(album, likeCount, liked, mapped);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gbsw/snapy/domain/feed/dto/response/FeedItemResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/feed/dto/response/FeedItemResponse.java
@@ -11,15 +11,20 @@ public record FeedItemResponse(
         Long albumId,
         LocalDate albumDate,
         int photoCount,
+        long likeCount,
+        boolean liked,
         List<AlbumDetailResponse.AlbumPhotoSet> photos,
         String authorName,
         String authorHandle
 ) {
-    public static FeedItemResponse of(DailyAlbum album, List<AlbumDetailResponse.AlbumPhotoSet> photos, User user) {
+    public static FeedItemResponse of(DailyAlbum album, long likeCount, boolean liked,
+                                      List<AlbumDetailResponse.AlbumPhotoSet> photos, User user) {
         return new FeedItemResponse(
                 album.getId(),
                 album.getAlbumDate(),
                 album.getPhotoCount(),
+                likeCount,
+                liked,
                 photos,
                 user.getUsername(),
                 user.getHandle()

--- a/src/main/java/com/gbsw/snapy/domain/feed/service/FeedService.java
+++ b/src/main/java/com/gbsw/snapy/domain/feed/service/FeedService.java
@@ -2,6 +2,7 @@ package com.gbsw.snapy.domain.feed.service;
 
 import com.gbsw.snapy.domain.albums.dto.response.AlbumDetailResponse;
 import com.gbsw.snapy.domain.albums.entity.DailyAlbum;
+import com.gbsw.snapy.domain.albums.repository.DailyAlbumLikeRepository;
 import com.gbsw.snapy.domain.albums.repository.DailyAlbumRepository;
 import com.gbsw.snapy.domain.albums.service.AlbumQueryService;
 import com.gbsw.snapy.domain.feed.dto.request.FeedRecommendRequest;
@@ -22,6 +23,8 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -33,6 +36,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class FeedService {
     private final DailyAlbumRepository dailyAlbumRepository;
+    private final DailyAlbumLikeRepository dailyAlbumLikeRepository;
     private final UserRepository userRepository;
     private final UserSettingRepository userSettingRepository;
     private final FriendRepository friendRepository;
@@ -70,7 +74,7 @@ public class FeedService {
         Map<Long, User> userById = userRepository.findAllById(ownerIds).stream()
                 .collect(Collectors.toMap(User::getId, Function.identity()));
 
-        List<FeedItemResponse> albumDetails = orderedAlbums.stream()
+        List<DailyAlbum> visibleAlbums = orderedAlbums.stream()
                 .filter((a) -> {
                     if (a.getUserId().equals(userId)) {
                         return true;
@@ -97,13 +101,28 @@ public class FeedService {
 
                     return true;
                 })
+                .toList();
+
+        List<Long> visibleAlbumIds = visibleAlbums.stream().map(DailyAlbum::getId).toList();
+        Map<Long, Long> likeCountByAlbumId = new HashMap<>();
+        Set<Long> likedAlbumIds = new HashSet<>();
+        if (!visibleAlbumIds.isEmpty()) {
+            dailyAlbumLikeRepository.countByAlbumIdIn(visibleAlbumIds)
+                    .forEach(p -> likeCountByAlbumId.put(p.getAlbumId(), p.getCount()));
+            dailyAlbumLikeRepository.findByAlbumIdInAndUserId(visibleAlbumIds, userId)
+                    .forEach(l -> likedAlbumIds.add(l.getAlbumId()));
+        }
+
+        List<FeedItemResponse> albumDetails = visibleAlbums.stream()
                 .map((a) -> {
                     LocalDateTime snapshotBoundary = a.getUserId().equals(userId) ? null : a.getPublishedAt();
                     List<AlbumQueryService.PhotoSetView> sets = albumQueryService.loadPhotoSets(a.getId(), snapshotBoundary);
                     List<AlbumDetailResponse.AlbumPhotoSet> mapped = sets.stream()
                             .map(s -> new AlbumDetailResponse.AlbumPhotoSet(s.type(), s.frontImageUrl(), s.backImageUrl(), s.createdAt()))
                             .toList();
-                    return FeedItemResponse.of(a, mapped, userById.get(a.getUserId()));
+                    long likeCount = likeCountByAlbumId.getOrDefault(a.getId(), 0L);
+                    boolean liked = likedAlbumIds.contains(a.getId());
+                    return FeedItemResponse.of(a, likeCount, liked, mapped, userById.get(a.getUserId()));
                 }).toList();
         return CursorResponse.of(albumDetails, response.getNextCursor(), response.getHasNext());
     }


### PR DESCRIPTION
### Type of PR
feat

### Changes
- `POST api/albums/{albumId}/likes`: 데일리 앨범 좋아요 토글 api 추가
- `GET api/albums/{albumId}`: 앨범 상세 조회 시 좋아요 수, 좋아요 토글 여부 응답 추가
- `GET api/feed`: 피드 조회 시 좋아요 수, 좋아요 토글 여부 응답 추가

### Additional

close #138 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 앨범에 좋아요 기능 추가: 인증된 사용자가 앨범을 좋아요/좋아요 취소할 수 있습니다.
  * 앨범 상세 페이지에 좋아요 수와 사용자의 좋아요 여부 표시
  * 피드 항목에 좋아요 수와 좋아요 상태 정보 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->