### PR TITLE
hotfix: Apple OAuth API 설정 누락으로 인증이 필요함 

### DIFF
--- a/src/main/java/com/gbsw/snapy/global/security/SecurityConfig.java
+++ b/src/main/java/com/gbsw/snapy/global/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
     private static final String[] PUBLIC_URLS = {
             "/api/auth/**",
             "/auth/google/**",
+            "/auth/apple/**",
             "/swagger-ui/**",
             "/v3/api-docs/**",
             "/swagger-ui.html",


### PR DESCRIPTION
### Type of PR
hotifx

### Changes
- Apple OAuth Api Public URL로 오픈

### Additional
#140 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Apple 인증 엔드포인트가 공개 경로에 추가되어 인증 없이 접근 가능하도록 설정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->