### PR TITLE
feat: 피드 좋아요 알림 추가

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumCommandService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumCommandService.java
@@ -14,6 +14,7 @@ import com.gbsw.snapy.domain.albums.repository.DailyAlbumLikeRepository;
 import com.gbsw.snapy.domain.albums.repository.DailyAlbumRepository;
 import com.gbsw.snapy.domain.friends.repository.FriendRepository;
 import com.gbsw.snapy.domain.notifications.event.AlbumPublishedEvent;
+import com.gbsw.snapy.domain.notifications.event.FeedLikedEvent;
 import com.gbsw.snapy.domain.notifications.event.NewStoryEvent;
 import com.gbsw.snapy.domain.settings.entity.UserSetting;
 import com.gbsw.snapy.domain.settings.entity.Visibility;
@@ -238,13 +239,18 @@ public class AlbumCommandService {
             dailyAlbumLikeRepository.delete(existing.get());
             liked = false;
         } else {
-            dailyAlbumLikeRepository.save(
+            DailyAlbumLike like = dailyAlbumLikeRepository.save(
                     DailyAlbumLike.builder()
                             .albumId(albumId)
                             .userId(userId)
                             .build()
             );
             liked = true;
+
+            if (!album.getUserId().equals(userId)) {
+                eventPublisher.publishEvent(new FeedLikedEvent(
+                        albumId, like.getId(), userId, album.getUserId()));
+            }
         }
 
         long likeCount = dailyAlbumLikeRepository.countByAlbumId(albumId);

--- a/src/main/java/com/gbsw/snapy/domain/notifications/entity/NotificationType.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/entity/NotificationType.java
@@ -3,6 +3,7 @@ package com.gbsw.snapy.domain.notifications.entity;
 public enum NotificationType {
     ALBUM_PHOTO_UPLOAD_REMINDER,
     STORY_LIKE,
+    FEED_LIKE,
     FRIEND_REQUEST,
     FRIEND_ACCEPTED,
     ALBUM_PUBLISHED,

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/FeedLikedEvent.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/FeedLikedEvent.java
@@ -1,0 +1,4 @@
+package com.gbsw.snapy.domain.notifications.event;
+
+public record FeedLikedEvent(Long albumId, Long likeId, Long senderId, Long ownerId) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
@@ -33,6 +33,19 @@ public class NotificationEventListener {
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFeedLiked(FeedLikedEvent event) {
+        try {
+            notificationService.create(
+                    event.ownerId(), event.senderId(),
+                    NotificationType.FEED_LIKE, event.likeId(), String.valueOf(event.albumId())
+            );
+        } catch (Exception e) {
+            log.warn("피드 좋아요 알림 생성 실패 - albumId: {}, likeId: {}",
+                    event.albumId(), event.likeId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleFeedComment(FeedCommentEvent event) {
         try {
             notificationService.create(

--- a/src/main/java/com/gbsw/snapy/infra/apns/ApnsPushService.java
+++ b/src/main/java/com/gbsw/snapy/infra/apns/ApnsPushService.java
@@ -85,6 +85,7 @@ public class ApnsPushService {
         return switch (type) {
             case ALBUM_PHOTO_UPLOAD_REMINDER -> "새 사진을 기록할 시간이에요.";
             case STORY_LIKE -> "회원님의 스토리에 하트가 도착했어요.";
+            case FEED_LIKE -> "회원님의 피드에 좋아요가 도착했어요.";
             case FRIEND_REQUEST -> "새 친구 요청이 도착했어요.";
             case FRIEND_ACCEPTED -> "친구 요청이 수락됐어요.";
             case ALBUM_PUBLISHED -> "친구가 새 게시물을 업로드했어요.";


### PR DESCRIPTION
### Type of PR
feat
### Changes
- NotificationType에 FEED_LIKE 추가
- 피드/앨범 좋아요 생성 시 FeedLikedEvent 발행
- FeedLikedEvent 수신 시 피드 작성자에게 좋아요 알림 생성
- APNs 푸시 메시지에 피드 좋아요 문구 추가
- 잘못 연결되어 있던 handleFeedLiked 이벤트 타입 수정
### Additional
- 본인 피드 좋아요는 알림 생성 제외
- close #154  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 피드 좋아요 알림 추가: 다른 사용자가 당신의 피드 항목을 좋아할 때 실시간 알림을 받습니다 (본인 콘텐츠에 대한 좋아요는 알림 제외)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-snapy/Server/pull/155)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->