### PR TITLE
fix: 프로필 월별 앨범 조회 시 게시된 앨범만 노출

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/repository/DailyAlbumRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/repository/DailyAlbumRepository.java
@@ -21,6 +21,9 @@ public interface DailyAlbumRepository extends JpaRepository<DailyAlbum, Long> {
     List<DailyAlbum> findByUserIdAndAlbumDateBetweenOrderByAlbumDateDesc(
             Long userId, LocalDate start, LocalDate end);
 
+    List<DailyAlbum> findByUserIdAndStatusAndAlbumDateBetweenOrderByAlbumDateDesc(
+            Long userId, AlbumStatus status, LocalDate start, LocalDate end);
+
     List<DailyAlbum> findByIdIn(List<Long> ids);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
@@ -150,12 +150,8 @@ public class AlbumQueryService {
         LocalDate end = yearMonth.atEndOfMonth();
 
         List<DailyAlbum> albums = dailyAlbumRepository
-                .findByUserIdAndAlbumDateBetweenOrderByAlbumDateDesc(targetUserId, start, end);
-        if (!isOwner) {
-            albums = albums.stream()
-                    .filter(a -> a.getStatus() == AlbumStatus.PUBLISHED)
-                    .toList();
-        }
+                .findByUserIdAndStatusAndAlbumDateBetweenOrderByAlbumDateDesc(
+                        targetUserId, AlbumStatus.PUBLISHED, start, end);
         return buildAlbumListResponses(albums);
     }
 


### PR DESCRIPTION
### Type of PR
fix
### Changes
- 프로필 월별 앨범 조회에서 자기 앨범 DRAFT 노출 분기 제거
- DailyAlbumRepository에 status 조건 포함 월별 조회 메서드 추가
- getAlbumsByMonth 조회 결과를 PUBLISHED 앨범으로 통일
### Additional
- 캘린더/오늘 앨범 조회 로직은 기존 동작 유지
- close #160 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 월별 앨범 조회 시 발행된 앨범만 표시하는 기능 추가
  * 날짜 범위 기반 앨범 필터링 개선

* **버그 수정**
  * 앨범 조회 로직 최적화로 인한 필터링 동작 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-snapy/Server/pull/161)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->