### PR TITLE
feat: 전역 rate limit 필터 추가

### DIFF
--- a/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
+++ b/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
+    RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "Too many requests. Please try again later."),
+
     // JWT
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),

--- a/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
+++ b/src/main/java/com/gbsw/snapy/global/exception/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
-    RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "Too many requests. Please try again later."),
+    RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
 
     // JWT
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),

--- a/src/main/java/com/gbsw/snapy/global/security/SecurityConfig.java
+++ b/src/main/java/com/gbsw/snapy/global/security/SecurityConfig.java
@@ -3,10 +3,13 @@ package com.gbsw.snapy.global.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gbsw.snapy.global.security.filter.JwtAuthenticationFilter;
 import com.gbsw.snapy.global.security.filter.PhoneRegistrationFilter;
+import com.gbsw.snapy.global.security.filter.RateLimitFilter;
 import com.gbsw.snapy.global.security.handler.CustomAccessDeniedHandler;
 import com.gbsw.snapy.global.security.handler.CustomAuthenticationEntryPoint;
 import com.gbsw.snapy.global.security.jwt.JwtProvider;
+import com.gbsw.snapy.global.security.ratelimit.RateLimitProperties;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -29,6 +32,7 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@EnableConfigurationProperties(RateLimitProperties.class)
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -36,6 +40,7 @@ public class SecurityConfig {
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     private final CustomAccessDeniedHandler accessDeniedHandler;
     private final ObjectMapper objectMapper;
+    private final RateLimitProperties rateLimitProperties;
 
     private static final String[] PUBLIC_URLS = {
             "/api/auth/**",
@@ -60,9 +65,15 @@ public class SecurityConfig {
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(authenticationEntryPoint)
                         .accessDeniedHandler(accessDeniedHandler))
+                .addFilterBefore(rateLimitFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(phoneRegistrationFilter(), JwtAuthenticationFilter.class)
                 .build();
+    }
+
+    @Bean
+    public RateLimitFilter rateLimitFilter() {
+        return new RateLimitFilter(rateLimitProperties, objectMapper);
     }
 
     @Bean

--- a/src/main/java/com/gbsw/snapy/global/security/filter/RateLimitFilter.java
+++ b/src/main/java/com/gbsw/snapy/global/security/filter/RateLimitFilter.java
@@ -18,6 +18,7 @@ import java.time.Clock;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 @RequiredArgsConstructor
 public class RateLimitFilter extends OncePerRequestFilter {
@@ -51,19 +52,24 @@ public class RateLimitFilter extends OncePerRequestFilter {
         cleanupExpiredCounters(now, windowMillis);
 
         String key = resolveClientIp(request);
-        RequestCounter counter = counters.compute(key, (ignored, current) -> {
+        AtomicReference<RateLimitResult> result = new AtomicReference<>();
+        counters.compute(key, (ignored, current) -> {
             if (current == null || current.isExpired(now)) {
-                return new RequestCounter(now + windowMillis, 1);
+                RequestCounter next = new RequestCounter(now + windowMillis, 1);
+                result.set(next.toResult());
+                return next;
             }
             current.increment();
+            result.set(current.toResult());
             return current;
         });
 
-        long remaining = Math.max(0, properties.getMaxRequests() - counter.getCount());
-        addRateLimitHeaders(response, counter, remaining);
+        RateLimitResult rateLimitResult = result.get();
+        long remaining = Math.max(0, properties.getMaxRequests() - rateLimitResult.count());
+        addRateLimitHeaders(response, rateLimitResult, remaining);
 
-        if (counter.getCount() > properties.getMaxRequests()) {
-            writeRateLimitResponse(response, counter);
+        if (rateLimitResult.count() > properties.getMaxRequests()) {
+            writeRateLimitResponse(response, rateLimitResult);
             return;
         }
 
@@ -93,14 +99,14 @@ public class RateLimitFilter extends OncePerRequestFilter {
         counters.entrySet().removeIf(entry -> entry.getValue().isExpired(now));
     }
 
-    private void addRateLimitHeaders(HttpServletResponse response, RequestCounter counter, long remaining) {
+    private void addRateLimitHeaders(HttpServletResponse response, RateLimitResult result, long remaining) {
         response.setHeader(X_RATE_LIMIT_LIMIT, String.valueOf(properties.getMaxRequests()));
         response.setHeader(X_RATE_LIMIT_REMAINING, String.valueOf(remaining));
-        response.setHeader(X_RATE_LIMIT_RESET, String.valueOf(counter.getResetAtEpochSeconds()));
+        response.setHeader(X_RATE_LIMIT_RESET, String.valueOf(result.resetAtEpochSeconds()));
     }
 
-    private void writeRateLimitResponse(HttpServletResponse response, RequestCounter counter) throws IOException {
-        long retryAfterSeconds = Math.max(1, (counter.getResetAtMillis() - clock.millis() + 999) / 1000);
+    private void writeRateLimitResponse(HttpServletResponse response, RateLimitResult result) throws IOException {
+        long retryAfterSeconds = Math.max(1, (result.resetAtMillis() - clock.millis() + 999) / 1000);
 
         response.setStatus(ErrorCode.RATE_LIMIT_EXCEEDED.getStatus().value());
         response.setHeader(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfterSeconds));
@@ -127,15 +133,14 @@ public class RateLimitFilter extends OncePerRequestFilter {
             count++;
         }
 
-        private int getCount() {
-            return count;
+        private RateLimitResult toResult() {
+            return new RateLimitResult(count, resetAtMillis);
         }
+    }
 
-        private long getResetAtMillis() {
-            return resetAtMillis;
-        }
+    private record RateLimitResult(int count, long resetAtMillis) {
 
-        private long getResetAtEpochSeconds() {
+        private long resetAtEpochSeconds() {
             return (resetAtMillis + 999) / 1000;
         }
     }

--- a/src/main/java/com/gbsw/snapy/global/security/filter/RateLimitFilter.java
+++ b/src/main/java/com/gbsw/snapy/global/security/filter/RateLimitFilter.java
@@ -1,0 +1,142 @@
+package com.gbsw.snapy.global.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gbsw.snapy.global.exception.ErrorCode;
+import com.gbsw.snapy.global.exception.ErrorResponse;
+import com.gbsw.snapy.global.security.ratelimit.RateLimitProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+@RequiredArgsConstructor
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private static final String X_FORWARDED_FOR = "X-Forwarded-For";
+    private static final String X_RATE_LIMIT_LIMIT = "X-RateLimit-Limit";
+    private static final String X_RATE_LIMIT_REMAINING = "X-RateLimit-Remaining";
+    private static final String X_RATE_LIMIT_RESET = "X-RateLimit-Reset";
+
+    private final RateLimitProperties properties;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+    private final ConcurrentMap<String, RequestCounter> counters = new ConcurrentHashMap<>();
+    private final AtomicLong lastCleanupAt = new AtomicLong();
+
+    public RateLimitFilter(RateLimitProperties properties, ObjectMapper objectMapper) {
+        this(properties, objectMapper, Clock.systemUTC());
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        if (!properties.isEnabled() || isPreflight(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        long now = clock.millis();
+        long windowMillis = properties.getWindow().toMillis();
+        cleanupExpiredCounters(now, windowMillis);
+
+        String key = resolveClientIp(request);
+        RequestCounter counter = counters.compute(key, (ignored, current) -> {
+            if (current == null || current.isExpired(now)) {
+                return new RequestCounter(now + windowMillis, 1);
+            }
+            current.increment();
+            return current;
+        });
+
+        long remaining = Math.max(0, properties.getMaxRequests() - counter.getCount());
+        addRateLimitHeaders(response, counter, remaining);
+
+        if (counter.getCount() > properties.getMaxRequests()) {
+            writeRateLimitResponse(response, counter);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isPreflight(HttpServletRequest request) {
+        return "OPTIONS".equalsIgnoreCase(request.getMethod());
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader(X_FORWARDED_FOR);
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    private void cleanupExpiredCounters(long now, long windowMillis) {
+        long cleanupInterval = Math.max(windowMillis, 1);
+        long previousCleanupAt = lastCleanupAt.get();
+        if (now - previousCleanupAt < cleanupInterval
+                || !lastCleanupAt.compareAndSet(previousCleanupAt, now)) {
+            return;
+        }
+
+        counters.entrySet().removeIf(entry -> entry.getValue().isExpired(now));
+    }
+
+    private void addRateLimitHeaders(HttpServletResponse response, RequestCounter counter, long remaining) {
+        response.setHeader(X_RATE_LIMIT_LIMIT, String.valueOf(properties.getMaxRequests()));
+        response.setHeader(X_RATE_LIMIT_REMAINING, String.valueOf(remaining));
+        response.setHeader(X_RATE_LIMIT_RESET, String.valueOf(counter.getResetAtEpochSeconds()));
+    }
+
+    private void writeRateLimitResponse(HttpServletResponse response, RequestCounter counter) throws IOException {
+        long retryAfterSeconds = Math.max(1, (counter.getResetAtMillis() - clock.millis() + 999) / 1000);
+
+        response.setStatus(ErrorCode.RATE_LIMIT_EXCEEDED.getStatus().value());
+        response.setHeader(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfterSeconds));
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.of(ErrorCode.RATE_LIMIT_EXCEEDED)));
+    }
+
+    private static class RequestCounter {
+
+        private final long resetAtMillis;
+        private int count;
+
+        private RequestCounter(long resetAtMillis, int count) {
+            this.resetAtMillis = resetAtMillis;
+            this.count = count;
+        }
+
+        private boolean isExpired(long now) {
+            return now >= resetAtMillis;
+        }
+
+        private void increment() {
+            count++;
+        }
+
+        private int getCount() {
+            return count;
+        }
+
+        private long getResetAtMillis() {
+            return resetAtMillis;
+        }
+
+        private long getResetAtEpochSeconds() {
+            return (resetAtMillis + 999) / 1000;
+        }
+    }
+}

--- a/src/main/java/com/gbsw/snapy/global/security/ratelimit/RateLimitProperties.java
+++ b/src/main/java/com/gbsw/snapy/global/security/ratelimit/RateLimitProperties.java
@@ -1,0 +1,17 @@
+package com.gbsw.snapy.global.security.ratelimit;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "rate-limit")
+public class RateLimitProperties {
+
+    private boolean enabled = true;
+    private int maxRequests = 100;
+    private Duration window = Duration.ofMinutes(1);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,11 @@ jwt:
   access-token-expiration: 1800000
   refresh-token-expiration: 604800000
 
+rate-limit:
+  enabled: true
+  max-requests: 100
+  window: 1m
+
 springdoc:
   api-docs:
     path: /v3/api-docs

--- a/src/test/java/com/gbsw/snapy/global/security/filter/RateLimitFilterTest.java
+++ b/src/test/java/com/gbsw/snapy/global/security/filter/RateLimitFilterTest.java
@@ -12,6 +12,12 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,7 +37,7 @@ class RateLimitFilterTest {
         assertThat(secondResponse.getStatus()).isEqualTo(200);
         assertThat(thirdResponse.getStatus()).isEqualTo(429);
         assertThat(thirdResponse.getHeader("Retry-After")).isEqualTo("60");
-        assertThat(thirdResponse.getContentAsString()).contains("Too many requests");
+        assertThat(thirdResponse.getContentAsString()).contains("요청이 너무 많습니다");
     }
 
     @Test
@@ -54,6 +60,33 @@ class RateLimitFilterTest {
         MockHttpServletResponse response = doFilter(filter, request);
 
         assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void countsConcurrentRequestsConsistently() throws Exception {
+        int maxRequests = 20;
+        int totalRequests = 50;
+        RateLimitFilter filter = new RateLimitFilter(properties(maxRequests), objectMapper(), FIXED_CLOCK);
+        ExecutorService executorService = Executors.newFixedThreadPool(8);
+        List<Callable<Integer>> tasks = IntStream.range(0, totalRequests)
+                .mapToObj(ignored -> (Callable<Integer>) () -> doFilter(filter, request("203.0.113.1")).getStatus())
+                .toList();
+
+        List<Integer> statuses = executorService.invokeAll(tasks).stream()
+                .map(future -> {
+                    try {
+                        return future.get();
+                    } catch (Exception e) {
+                        throw new IllegalStateException(e);
+                    }
+                })
+                .toList();
+        executorService.shutdown();
+        boolean terminated = executorService.awaitTermination(1, TimeUnit.SECONDS);
+
+        assertThat(terminated).isTrue();
+        assertThat(statuses).filteredOn(status -> status == 200).hasSize(maxRequests);
+        assertThat(statuses).filteredOn(status -> status == 429).hasSize(totalRequests - maxRequests);
     }
 
     private RateLimitProperties properties(int maxRequests) {

--- a/src/test/java/com/gbsw/snapy/global/security/filter/RateLimitFilterTest.java
+++ b/src/test/java/com/gbsw/snapy/global/security/filter/RateLimitFilterTest.java
@@ -1,0 +1,89 @@
+package com.gbsw.snapy.global.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.gbsw.snapy.global.security.ratelimit.RateLimitProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RateLimitFilterTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-05-14T00:00:00Z"), ZoneOffset.UTC);
+
+    @Test
+    void blocksRequestsOverLimit() throws Exception {
+        RateLimitFilter filter = new RateLimitFilter(properties(2), objectMapper(), FIXED_CLOCK);
+
+        MockHttpServletResponse firstResponse = doFilter(filter, request("203.0.113.1"));
+        MockHttpServletResponse secondResponse = doFilter(filter, request("203.0.113.1"));
+        MockHttpServletResponse thirdResponse = doFilter(filter, request("203.0.113.1"));
+
+        assertThat(firstResponse.getStatus()).isEqualTo(200);
+        assertThat(secondResponse.getStatus()).isEqualTo(200);
+        assertThat(thirdResponse.getStatus()).isEqualTo(429);
+        assertThat(thirdResponse.getHeader("Retry-After")).isEqualTo("60");
+        assertThat(thirdResponse.getContentAsString()).contains("Too many requests");
+    }
+
+    @Test
+    void usesFirstForwardedForIpAsClientKey() throws Exception {
+        RateLimitFilter filter = new RateLimitFilter(properties(1), objectMapper(), FIXED_CLOCK);
+
+        MockHttpServletResponse firstResponse = doFilter(filter, request("198.51.100.10", "203.0.113.10, 198.51.100.10"));
+        MockHttpServletResponse secondResponse = doFilter(filter, request("198.51.100.11", "203.0.113.10, 198.51.100.11"));
+
+        assertThat(firstResponse.getStatus()).isEqualTo(200);
+        assertThat(secondResponse.getStatus()).isEqualTo(429);
+    }
+
+    @Test
+    void skipsOptionsPreflight() throws Exception {
+        RateLimitFilter filter = new RateLimitFilter(properties(0), objectMapper(), FIXED_CLOCK);
+        MockHttpServletRequest request = request("203.0.113.1");
+        request.setMethod("OPTIONS");
+
+        MockHttpServletResponse response = doFilter(filter, request);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    private RateLimitProperties properties(int maxRequests) {
+        RateLimitProperties properties = new RateLimitProperties();
+        properties.setEnabled(true);
+        properties.setMaxRequests(maxRequests);
+        properties.setWindow(Duration.ofMinutes(1));
+        return properties;
+    }
+
+    private ObjectMapper objectMapper() {
+        return new ObjectMapper().registerModule(new JavaTimeModule());
+    }
+
+    private MockHttpServletRequest request(String remoteAddr) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr(remoteAddr);
+        request.setRequestURI("/api/albums");
+        return request;
+    }
+
+    private MockHttpServletRequest request(String remoteAddr, String forwardedFor) {
+        MockHttpServletRequest request = request(remoteAddr);
+        request.addHeader("X-Forwarded-For", forwardedFor);
+        return request;
+    }
+
+    private MockHttpServletResponse doFilter(RateLimitFilter filter, MockHttpServletRequest request) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request, response, new MockFilterChain());
+        return response;
+    }
+}


### PR DESCRIPTION
### Type of PR
feat
### Changes
- 전역 RateLimitFilter 추가
- IP 기준 요청 제한 및 X-Forwarded-For 첫 IP 지원
- 요청 초과 시 429 응답과 Retry-After, X-RateLimit-* 헤더 반환
- ErrorCode에 RATE_LIMIT_EXCEEDED 추가
- RateLimitFilter 단위 테스트 추가
### Additional
- 도메인별로 나누지 않고 전체 요청에 공통 적용
- CORS preflight OPTIONS 요청은 rate limit 대상에서 제외
- IP당 최대 요청 횟수는 1분에 100회로 설정
- close #157 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 속도 제한 기능 추가: 클라이언트당 분당 100개 요청으로 제한되며, 초과 시 429 상태 코드와 함께 `Retry-After` 헤더 반환

* **Tests**
  * 속도 제한 필터에 대한 종합 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-snapy/Server/pull/169)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->