### PR TITLE
fix: 중복 피드 좋아요 푸시알림 방지

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/notifications/entity/Notification.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/entity/Notification.java
@@ -6,10 +6,16 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "notifications", indexes = {
-        @Index(name = "idx_notification_receiver_created", columnList = "receiver_id, created_at"),
-        @Index(name = "idx_notification_receiver_unread", columnList = "receiver_id, is_read")
-})
+@Table(
+        name = "notifications",
+        indexes = {
+                @Index(name = "idx_notification_receiver_created", columnList = "receiver_id, created_at"),
+                @Index(name = "idx_notification_receiver_unread", columnList = "receiver_id, is_read")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_notification_deduplication_key", columnNames = "deduplication_key")
+        }
+)
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,6 +41,9 @@ public class Notification {
 
     @Column(name = "reference_type", length = 20)
     private String referenceType;
+
+    @Column(name = "deduplication_key", length = 100)
+    private String deduplicationKey;
 
     @Column(name = "is_read", nullable = false)
     private boolean read;

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
@@ -35,10 +35,8 @@ public class NotificationEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleFeedLiked(FeedLikedEvent event) {
         try {
-            notificationService.create(
-                    event.ownerId(), event.senderId(),
-                    NotificationType.FEED_LIKE, event.likeId(), String.valueOf(event.albumId())
-            );
+            notificationService.createFeedLikeIfAbsent(
+                    event.ownerId(), event.senderId(), event.likeId(), event.albumId());
         } catch (Exception e) {
             log.warn("피드 좋아요 알림 생성 실패 - albumId: {}, likeId: {}",
                     event.albumId(), event.likeId(), e);

--- a/src/main/java/com/gbsw/snapy/domain/notifications/repository/NotificationRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/repository/NotificationRepository.java
@@ -1,6 +1,7 @@
 package com.gbsw.snapy.domain.notifications.repository;
 
 import com.gbsw.snapy.domain.notifications.entity.Notification;
+import com.gbsw.snapy.domain.notifications.entity.NotificationType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,6 +14,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Slice<Notification> findByReceiverIdOrderByCreatedAtDesc(Long receiverId, Pageable pageable);
 
     long countByReceiverIdAndReadFalse(Long receiverId);
+
+    boolean existsByReceiverIdAndSenderIdAndTypeAndReferenceType(
+            Long receiverId, Long senderId, NotificationType type, String referenceType);
 
     @Modifying
     @Query("UPDATE Notification n SET n.read = true WHERE n.receiverId = :receiverId AND n.read = false")

--- a/src/main/java/com/gbsw/snapy/domain/notifications/repository/NotificationRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/repository/NotificationRepository.java
@@ -1,7 +1,6 @@
 package com.gbsw.snapy.domain.notifications.repository;
 
 import com.gbsw.snapy.domain.notifications.entity.Notification;
-import com.gbsw.snapy.domain.notifications.entity.NotificationType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,8 +14,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     long countByReceiverIdAndReadFalse(Long receiverId);
 
-    boolean existsByReceiverIdAndSenderIdAndTypeAndReferenceType(
-            Long receiverId, Long senderId, NotificationType type, String referenceType);
+    boolean existsByDeduplicationKey(String deduplicationKey);
 
     @Modifying
     @Query("UPDATE Notification n SET n.read = true WHERE n.receiverId = :receiverId AND n.read = false")

--- a/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
@@ -49,6 +49,18 @@ public class NotificationService {
         apnsPushService.sendToUser(receiverId, type);
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createFeedLikeIfAbsent(Long receiverId, Long senderId, Long likeId, Long albumId) {
+        String albumReference = String.valueOf(albumId);
+        boolean alreadyNotified = notificationRepository.existsByReceiverIdAndSenderIdAndTypeAndReferenceType(
+                receiverId, senderId, NotificationType.FEED_LIKE, albumReference);
+        if (alreadyNotified) {
+            return;
+        }
+
+        create(receiverId, senderId, NotificationType.FEED_LIKE, likeId, albumReference);
+    }
+
     @Transactional(readOnly = true)
     public NotificationPageResponse getNotifications(Long userId, Pageable pageable) {
         Slice<Notification> slice = notificationRepository

--- a/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
@@ -12,6 +12,7 @@ import com.gbsw.snapy.global.exception.CustomException;
 import com.gbsw.snapy.global.exception.ErrorCode;
 import com.gbsw.snapy.infra.apns.ApnsPushService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -52,13 +53,31 @@ public class NotificationService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void createFeedLikeIfAbsent(Long receiverId, Long senderId, Long likeId, Long albumId) {
         String albumReference = String.valueOf(albumId);
-        boolean alreadyNotified = notificationRepository.existsByReceiverIdAndSenderIdAndTypeAndReferenceType(
-                receiverId, senderId, NotificationType.FEED_LIKE, albumReference);
-        if (alreadyNotified) {
+        String deduplicationKey = feedLikeDeduplicationKey(receiverId, senderId, albumId);
+        if (notificationRepository.existsByDeduplicationKey(deduplicationKey)) {
             return;
         }
 
-        create(receiverId, senderId, NotificationType.FEED_LIKE, likeId, albumReference);
+        try {
+            notificationRepository.saveAndFlush(
+                    Notification.builder()
+                            .receiverId(receiverId)
+                            .senderId(senderId)
+                            .type(NotificationType.FEED_LIKE)
+                            .referenceId(likeId)
+                            .referenceType(albumReference)
+                            .deduplicationKey(deduplicationKey)
+                            .read(false)
+                            .build()
+            );
+        } catch (DataIntegrityViolationException e) {
+            return;
+        }
+        apnsPushService.sendToUser(receiverId, NotificationType.FEED_LIKE);
+    }
+
+    private String feedLikeDeduplicationKey(Long receiverId, Long senderId, Long albumId) {
+        return NotificationType.FEED_LIKE + ":" + receiverId + ":" + senderId + ":" + albumId;
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/gbsw/snapy/domain/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/com/gbsw/snapy/domain/notifications/service/NotificationServiceTest.java
@@ -1,0 +1,67 @@
+package com.gbsw.snapy.domain.notifications.service;
+
+import com.gbsw.snapy.domain.notifications.entity.Notification;
+import com.gbsw.snapy.domain.notifications.entity.NotificationType;
+import com.gbsw.snapy.domain.notifications.repository.NotificationRepository;
+import com.gbsw.snapy.domain.users.repository.UserRepository;
+import com.gbsw.snapy.infra.apns.ApnsPushService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ApnsPushService apnsPushService;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    @Test
+    void createFeedLikeIfAbsentSkipsDuplicateNotificationAndPush() {
+        when(notificationRepository.existsByReceiverIdAndSenderIdAndTypeAndReferenceType(
+                1L, 2L, NotificationType.FEED_LIKE, "10"))
+                .thenReturn(true);
+
+        notificationService.createFeedLikeIfAbsent(1L, 2L, 100L, 10L);
+
+        verify(notificationRepository, never()).save(any(Notification.class));
+        verify(apnsPushService, never()).sendToUser(any(), any());
+    }
+
+    @Test
+    void createFeedLikeIfAbsentCreatesNotificationAndPushWhenNotExists() {
+        when(notificationRepository.existsByReceiverIdAndSenderIdAndTypeAndReferenceType(
+                1L, 2L, NotificationType.FEED_LIKE, "10"))
+                .thenReturn(false);
+
+        notificationService.createFeedLikeIfAbsent(1L, 2L, 100L, 10L);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        Notification notification = captor.getValue();
+        assertThat(notification.getReceiverId()).isEqualTo(1L);
+        assertThat(notification.getSenderId()).isEqualTo(2L);
+        assertThat(notification.getType()).isEqualTo(NotificationType.FEED_LIKE);
+        assertThat(notification.getReferenceId()).isEqualTo(100L);
+        assertThat(notification.getReferenceType()).isEqualTo("10");
+        assertThat(notification.isRead()).isFalse();
+        verify(apnsPushService).sendToUser(1L, NotificationType.FEED_LIKE);
+    }
+}

--- a/src/test/java/com/gbsw/snapy/domain/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/com/gbsw/snapy/domain/notifications/service/NotificationServiceTest.java
@@ -7,6 +7,7 @@ import com.gbsw.snapy.domain.users.repository.UserRepository;
 import com.gbsw.snapy.infra.apns.ApnsPushService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -35,33 +36,41 @@ class NotificationServiceTest {
 
     @Test
     void createFeedLikeIfAbsentSkipsDuplicateNotificationAndPush() {
-        when(notificationRepository.existsByReceiverIdAndSenderIdAndTypeAndReferenceType(
-                1L, 2L, NotificationType.FEED_LIKE, "10"))
-                .thenReturn(true);
+        when(notificationRepository.existsByDeduplicationKey("FEED_LIKE:1:2:10")).thenReturn(true);
 
         notificationService.createFeedLikeIfAbsent(1L, 2L, 100L, 10L);
 
-        verify(notificationRepository, never()).save(any(Notification.class));
+        verify(notificationRepository, never()).saveAndFlush(any(Notification.class));
         verify(apnsPushService, never()).sendToUser(any(), any());
     }
 
     @Test
     void createFeedLikeIfAbsentCreatesNotificationAndPushWhenNotExists() {
-        when(notificationRepository.existsByReceiverIdAndSenderIdAndTypeAndReferenceType(
-                1L, 2L, NotificationType.FEED_LIKE, "10"))
-                .thenReturn(false);
+        when(notificationRepository.existsByDeduplicationKey("FEED_LIKE:1:2:10")).thenReturn(false);
 
         notificationService.createFeedLikeIfAbsent(1L, 2L, 100L, 10L);
 
         ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
-        verify(notificationRepository).save(captor.capture());
+        verify(notificationRepository).saveAndFlush(captor.capture());
         Notification notification = captor.getValue();
         assertThat(notification.getReceiverId()).isEqualTo(1L);
         assertThat(notification.getSenderId()).isEqualTo(2L);
         assertThat(notification.getType()).isEqualTo(NotificationType.FEED_LIKE);
         assertThat(notification.getReferenceId()).isEqualTo(100L);
         assertThat(notification.getReferenceType()).isEqualTo("10");
+        assertThat(notification.getDeduplicationKey()).isEqualTo("FEED_LIKE:1:2:10");
         assertThat(notification.isRead()).isFalse();
         verify(apnsPushService).sendToUser(1L, NotificationType.FEED_LIKE);
+    }
+
+    @Test
+    void createFeedLikeIfAbsentSkipsPushWhenConcurrentInsertWins() {
+        when(notificationRepository.existsByDeduplicationKey("FEED_LIKE:1:2:10")).thenReturn(false);
+        when(notificationRepository.saveAndFlush(any(Notification.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate"));
+
+        notificationService.createFeedLikeIfAbsent(1L, 2L, 100L, 10L);
+
+        verify(apnsPushService, never()).sendToUser(any(), any());
     }
 }


### PR DESCRIPTION
### Type of PR
fix
### Changes
- FEED_LIKE 알림 중복 여부를 receiverId, senderId, type, albumId 기준으로 확인
- 같은 피드 좋아요 알림이 이미 있으면 알림 저장과 APNs 푸시 전송 생략
- NotificationEventListener에서 피드 좋아요 알림 생성 시 중복 방지 메서드 사용
- NotificationService 단위 테스트 추가
### Additional
- Redis 마이그레이션 시 createFeedLikeIfAbsent 내부 중복 판단만 Redis TTL 키 기반으로 교체하면 됨
- close #177 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 피드 좋아요 알림 중복 방지: 동일한 게시물에 대한 좋아요 알림이 여러 번 중복으로 전송되지 않도록 개선되었습니다. 사용자는 이제 새로운 좋아요에만 알림을 받게 되어, 불필요한 중복 알림으로 인한 혼선을 효과적으로 줄일 수 있으며 알림 환경이 더욱 개선됩니다.

* **테스트**
  * 피드 좋아요 알림 기능의 안정성 검증: 중복 방지 기능과 정상 작동 시나리오를 모두 테스트하여 시스템의 신뢰성을 확보했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-snapy/Server/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->