### PR TITLE
fix: 자동 앨범 발행 푸시알림 비활성화

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumCommandService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumCommandService.java
@@ -199,7 +199,7 @@ public class AlbumCommandService {
 
         streakService.recordPublish(album.getUserId());
 
-        eventPublisher.publishEvent(new AlbumPublishedEvent(album.getId(), album.getUserId()));
+        eventPublisher.publishEvent(new AlbumPublishedEvent(album.getId(), album.getUserId(), false));
     }
 
     @Transactional

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/AlbumPublishedEvent.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/AlbumPublishedEvent.java
@@ -1,4 +1,8 @@
 package com.gbsw.snapy.domain.notifications.event;
 
-public record AlbumPublishedEvent(Long albumId, Long userId) {
+public record AlbumPublishedEvent(Long albumId, Long userId, boolean pushEnabled) {
+
+    public AlbumPublishedEvent(Long albumId, Long userId) {
+        this(albumId, userId, true);
+    }
 }

--- a/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/event/NotificationEventListener.java
@@ -98,10 +98,17 @@ public class NotificationEventListener {
         List<Long> friendIds = friendRepository.findFriendIdsByUserId(event.userId());
         for (Long friendId : friendIds) {
             try {
-                notificationService.create(
-                        friendId, event.userId(),
-                        NotificationType.ALBUM_PUBLISHED, event.albumId(), null
-                );
+                if (event.pushEnabled()) {
+                    notificationService.create(
+                            friendId, event.userId(),
+                            NotificationType.ALBUM_PUBLISHED, event.albumId(), null
+                    );
+                } else {
+                    notificationService.createWithoutPush(
+                            friendId, event.userId(),
+                            NotificationType.ALBUM_PUBLISHED, event.albumId(), null
+                    );
+                }
             } catch (Exception e) {
                 log.warn("앨범 게시 알림 생성 실패 - albumId: {}, friendId: {}",
                         event.albumId(), friendId, e);

--- a/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
@@ -37,6 +37,17 @@ public class NotificationService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void create(Long receiverId, Long senderId, NotificationType type,
                        Long referenceId, String referenceType) {
+        create(receiverId, senderId, type, referenceId, referenceType, true);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createWithoutPush(Long receiverId, Long senderId, NotificationType type,
+                                  Long referenceId, String referenceType) {
+        create(receiverId, senderId, type, referenceId, referenceType, false);
+    }
+
+    private void create(Long receiverId, Long senderId, NotificationType type,
+                        Long referenceId, String referenceType, boolean pushEnabled) {
         notificationRepository.save(
                 Notification.builder()
                         .receiverId(receiverId)
@@ -47,7 +58,9 @@ public class NotificationService {
                         .read(false)
                         .build()
         );
-        apnsPushService.sendToUser(receiverId, type);
+        if (pushEnabled) {
+            apnsPushService.sendToUser(receiverId, type);
+        }
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/test/java/com/gbsw/snapy/domain/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/com/gbsw/snapy/domain/notifications/service/NotificationServiceTest.java
@@ -45,6 +45,22 @@ class NotificationServiceTest {
     }
 
     @Test
+    void createWithoutPushCreatesNotificationAndSkipsPush() {
+        notificationService.createWithoutPush(1L, 2L, NotificationType.ALBUM_PUBLISHED, 10L, null);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        Notification notification = captor.getValue();
+        assertThat(notification.getReceiverId()).isEqualTo(1L);
+        assertThat(notification.getSenderId()).isEqualTo(2L);
+        assertThat(notification.getType()).isEqualTo(NotificationType.ALBUM_PUBLISHED);
+        assertThat(notification.getReferenceId()).isEqualTo(10L);
+        assertThat(notification.getReferenceType()).isNull();
+        assertThat(notification.isRead()).isFalse();
+        verify(apnsPushService, never()).sendToUser(any(), any());
+    }
+
+    @Test
     void createFeedLikeIfAbsentCreatesNotificationAndPushWhenNotExists() {
         when(notificationRepository.existsByDeduplicationKey("FEED_LIKE:1:2:10")).thenReturn(false);
 


### PR DESCRIPTION
### Type of PR
fix
### Changes
- AlbumPublishedEvent에 pushEnabled 플래그 추가
- 수동 앨범 발행은 기존처럼 ALBUM_PUBLISHED 알림 생성 및 푸시 전송 유지
- 12시 자동 앨범 발행은 ALBUM_PUBLISHED 알림만 생성하고 APNs 푸시 전송 생략
- NotificationService에 createWithoutPush 메서드 추가
- 알림 저장 후 푸시를 보내지 않는 단위 테스트 추가
### Additional
- 12시 자동 업로드로 친구 게시물 발행 알림이 한꺼번에 푸시되는 문제를 방지
- close #179 