### PR TITLE
feat: 피드 좋아요 조회 API 추가

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/controller/AlbumController.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/controller/AlbumController.java
@@ -2,6 +2,7 @@ package com.gbsw.snapy.domain.albums.controller;
 
 import com.gbsw.snapy.domain.albums.dto.request.AlbumUploadRequest;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumDetailResponse;
+import com.gbsw.snapy.domain.albums.dto.response.AlbumLikeListResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumLikeResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumListResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumPublishResponse;
@@ -86,6 +87,15 @@ public class AlbumController {
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
         AlbumLikeResponse response = albumCommandService.toggleLike(albumId, principal.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{albumId}/likes")
+    public ResponseEntity<ApiResponse<List<AlbumLikeListResponse>>> getLikes(
+            @PathVariable Long albumId,
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        List<AlbumLikeListResponse> response = albumQueryService.getLikes(albumId, principal.getId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/albums/dto/response/AlbumLikeListResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/dto/response/AlbumLikeListResponse.java
@@ -1,0 +1,12 @@
+package com.gbsw.snapy.domain.albums.dto.response;
+
+import java.time.LocalDateTime;
+
+public record AlbumLikeListResponse(
+        Long userId,
+        String handle,
+        String username,
+        String profileImageUrl,
+        LocalDateTime likedAt
+) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/albums/repository/DailyAlbumLikeRepository.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/repository/DailyAlbumLikeRepository.java
@@ -21,6 +21,8 @@ public interface DailyAlbumLikeRepository extends JpaRepository<DailyAlbumLike, 
 
     List<DailyAlbumLike> findByAlbumIdInAndUserId(Collection<Long> albumIds, Long userId);
 
+    List<DailyAlbumLike> findByAlbumIdOrderByCreatedAtDesc(Long albumId);
+
     @Query("SELECT l.albumId AS albumId, COUNT(l) AS count " +
             "FROM DailyAlbumLike l WHERE l.albumId IN :albumIds GROUP BY l.albumId")
     List<AlbumLikeCountProjection> countByAlbumIdIn(@Param("albumIds") Collection<Long> albumIds);

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
@@ -1,12 +1,14 @@
 package com.gbsw.snapy.domain.albums.service;
 
 import com.gbsw.snapy.domain.albums.dto.response.AlbumDetailResponse;
+import com.gbsw.snapy.domain.albums.dto.response.AlbumLikeListResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumListResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumTodayResponse;
 import com.gbsw.snapy.domain.albums.entity.AlbumPhoto;
 import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
 import com.gbsw.snapy.domain.albums.entity.AlbumStatus;
 import com.gbsw.snapy.domain.albums.entity.DailyAlbum;
+import com.gbsw.snapy.domain.albums.entity.DailyAlbumLike;
 import com.gbsw.snapy.domain.albums.repository.AlbumPhotoRepository;
 import com.gbsw.snapy.domain.albums.repository.DailyAlbumLikeRepository;
 import com.gbsw.snapy.domain.albums.repository.DailyAlbumRepository;
@@ -17,6 +19,7 @@ import com.gbsw.snapy.domain.photos.repository.PhotoRepository;
 import com.gbsw.snapy.domain.settings.entity.UserSetting;
 import com.gbsw.snapy.domain.settings.entity.Visibility;
 import com.gbsw.snapy.domain.settings.repository.UserSettingRepository;
+import com.gbsw.snapy.domain.users.entity.User;
 import com.gbsw.snapy.domain.users.repository.UserRepository;
 import com.gbsw.snapy.global.exception.CustomException;
 import com.gbsw.snapy.global.exception.ErrorCode;
@@ -33,6 +36,8 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -102,6 +107,37 @@ public class AlbumQueryService {
         long likeCount = dailyAlbumLikeRepository.countByAlbumId(album.getId());
         boolean liked = dailyAlbumLikeRepository.existsByAlbumIdAndUserId(album.getId(), userId);
         return AlbumDetailResponse.of(album, likeCount, liked, mapped);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AlbumLikeListResponse> getLikes(Long albumId, Long userId) {
+        dailyAlbumRepository.findById(albumId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
+
+        List<DailyAlbumLike> likes = dailyAlbumLikeRepository.findByAlbumIdOrderByCreatedAtDesc(albumId);
+        if (likes.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> likeUserIds = likes.stream().map(DailyAlbumLike::getUserId).toList();
+        Map<Long, User> userMap = userRepository.findAllById(likeUserIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        List<AlbumLikeListResponse> result = new ArrayList<>();
+        for (DailyAlbumLike like : likes) {
+            User user = userMap.get(like.getUserId());
+            if (user == null) continue;
+
+            result.add(new AlbumLikeListResponse(
+                    user.getId(),
+                    user.getHandle(),
+                    user.getUsername(),
+                    user.getProfileImageUrl(),
+                    like.getCreatedAt()
+            ));
+        }
+
+        return result;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
@@ -73,30 +73,7 @@ public class AlbumQueryService {
         DailyAlbum album = dailyAlbumRepository.findById(albumId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
 
-        if (!album.getUserId().equals(userId)) {
-            if (album.getStatus() != AlbumStatus.PUBLISHED) {
-                throw new CustomException(ErrorCode.ACCESS_DENIED);
-            }
-
-            YearMonth albumMonth = YearMonth.from(album.getAlbumDate());
-            YearMonth currentMonth = YearMonth.now(KST_ZONE);
-            boolean isCurrentMonth = albumMonth.equals(currentMonth);
-
-            UserSetting setting = userSettingRepository.findById(album.getUserId()).orElse(null);
-
-            Visibility v;
-            if (isCurrentMonth) {
-                v = (setting != null) ? setting.getFeedVisibility() : Visibility.FRIENDS_ONLY;
-            } else {
-                v = (setting != null) ? setting.getPastAlbumVisibility() : Visibility.FRIENDS_ONLY;
-                if (v == Visibility.ONLY_ME) {
-                    throw new CustomException(ErrorCode.ACCESS_DENIED);
-                }
-            }
-            if (v == Visibility.FRIENDS_ONLY && !friendRepository.existsFriendship(userId, album.getUserId())) {
-                throw new CustomException(ErrorCode.ACCESS_DENIED);
-            }
-        }
+        validateAlbumReadable(album, userId);
 
         LocalDateTime snapshotBoundary = album.getUserId().equals(userId) ? null : album.getPublishedAt();
         List<PhotoSetView> sets = loadPhotoSets(album.getId(), snapshotBoundary);
@@ -111,8 +88,9 @@ public class AlbumQueryService {
 
     @Transactional(readOnly = true)
     public List<AlbumLikeListResponse> getLikes(Long albumId, Long userId) {
-        dailyAlbumRepository.findById(albumId)
+        DailyAlbum album = dailyAlbumRepository.findById(albumId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
+        validateAlbumReadable(album, userId);
 
         List<DailyAlbumLike> likes = dailyAlbumLikeRepository.findByAlbumIdOrderByCreatedAtDesc(albumId);
         if (likes.isEmpty()) {
@@ -138,6 +116,36 @@ public class AlbumQueryService {
         }
 
         return result;
+    }
+
+    private void validateAlbumReadable(DailyAlbum album, Long userId) {
+        if (album.getUserId().equals(userId)) {
+            return;
+        }
+
+        if (album.getStatus() != AlbumStatus.PUBLISHED) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        YearMonth albumMonth = YearMonth.from(album.getAlbumDate());
+        YearMonth currentMonth = YearMonth.now(KST_ZONE);
+        boolean isCurrentMonth = albumMonth.equals(currentMonth);
+
+        UserSetting setting = userSettingRepository.findById(album.getUserId()).orElse(null);
+
+        Visibility visibility;
+        if (isCurrentMonth) {
+            visibility = (setting != null) ? setting.getFeedVisibility() : Visibility.FRIENDS_ONLY;
+        } else {
+            visibility = (setting != null) ? setting.getPastAlbumVisibility() : Visibility.FRIENDS_ONLY;
+            if (visibility == Visibility.ONLY_ME) {
+                throw new CustomException(ErrorCode.ACCESS_DENIED);
+            }
+        }
+
+        if (visibility == Visibility.FRIENDS_ONLY && !friendRepository.existsFriendship(userId, album.getUserId())) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
### Type of PR
feat
### Changes
- GET /api/albums/{albumId}/likes API 추가
- AlbumLikeListResponse DTO 추가
- 피드 좋아요 목록을 모든 인증 사용자가 조회 가능하도록 구현
- 좋아요 목록을 likedAt 최신순으로 반환
### Additional
- close #182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 앨범의 좋아요 목록 조회 기능이 추가되었습니다. 이제 각 앨범에 대해 좋아요를 누른 사용자들의 프로필 정보(사용자명, 프로필 이미지, 좋아요 시간)를 확인할 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-snapy/Server/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->