### PR TITLE
refactor: 프로필 신고 대상을 userHandle로 변경

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/reports/dto/request/ReportCreateRequest.java
+++ b/src/main/java/com/gbsw/snapy/domain/reports/dto/request/ReportCreateRequest.java
@@ -2,18 +2,34 @@ package com.gbsw.snapy.domain.reports.dto.request;
 
 import com.gbsw.snapy.domain.reports.entity.ReportReason;
 import com.gbsw.snapy.domain.reports.entity.ReportTargetType;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 
 public record ReportCreateRequest(
         @NotNull(message = "신고 대상 타입은 필수입니다.")
         ReportTargetType targetType,
 
-        @NotNull(message = "신고 대상 ID는 필수입니다.")
         @Positive(message = "신고 대상 ID는 양수여야 합니다.")
         Long targetId,
+
+        @Size(max = 25, message = "신고 대상 핸들은 25자를 초과할 수 없습니다.")
+        String targetHandle,
 
         @NotNull(message = "신고 사유는 필수입니다.")
         ReportReason reason
 ) {
+    @AssertTrue(message = "신고 대상 정보가 올바르지 않습니다.")
+    public boolean isValidTargetValue() {
+        if (targetType == null) {
+            return true;
+        }
+
+        if (targetType == ReportTargetType.PROFILE) {
+            return targetHandle != null && !targetHandle.isBlank();
+        }
+
+        return targetId != null;
+    }
 }

--- a/src/main/java/com/gbsw/snapy/domain/reports/dto/response/ReportCreateResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/reports/dto/response/ReportCreateResponse.java
@@ -8,6 +8,7 @@ public record ReportCreateResponse(
         Long reportId,
         ReportTargetType targetType,
         Long targetId,
+        String targetHandle,
         ReportReason reason
 ) {
     public static ReportCreateResponse from(Report report) {
@@ -15,6 +16,7 @@ public record ReportCreateResponse(
                 report.getId(),
                 report.getTargetType(),
                 report.getTargetId(),
+                report.getTargetHandle(),
                 report.getReason()
         );
     }

--- a/src/main/java/com/gbsw/snapy/domain/reports/entity/Report.java
+++ b/src/main/java/com/gbsw/snapy/domain/reports/entity/Report.java
@@ -36,8 +36,11 @@ public class Report {
     @Column(name = "target_type", nullable = false, length = 20)
     private ReportTargetType targetType;
 
-    @Column(name = "target_id", nullable = false)
+    @Column(name = "target_id")
     private Long targetId;
+
+    @Column(name = "target_handle", length = 25)
+    private String targetHandle;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)

--- a/src/main/java/com/gbsw/snapy/domain/reports/service/ReportService.java
+++ b/src/main/java/com/gbsw/snapy/domain/reports/service/ReportService.java
@@ -4,6 +4,7 @@ import com.gbsw.snapy.domain.albums.repository.DailyAlbumRepository;
 import com.gbsw.snapy.domain.reports.dto.request.ReportCreateRequest;
 import com.gbsw.snapy.domain.reports.dto.response.ReportCreateResponse;
 import com.gbsw.snapy.domain.reports.entity.Report;
+import com.gbsw.snapy.domain.reports.entity.ReportTargetType;
 import com.gbsw.snapy.domain.reports.repository.ReportRepository;
 import com.gbsw.snapy.domain.stories.repository.StoryRepository;
 import com.gbsw.snapy.domain.users.repository.UserRepository;
@@ -29,7 +30,8 @@ public class ReportService {
         Report report = reportRepository.save(Report.builder()
                 .reporterId(reporterId)
                 .targetType(request.targetType())
-                .targetId(request.targetId())
+                .targetId(resolveTargetId(request))
+                .targetHandle(resolveTargetHandle(request))
                 .reason(request.reason())
                 .build());
 
@@ -40,11 +42,27 @@ public class ReportService {
         boolean exists = switch (request.targetType()) {
             case FEED -> dailyAlbumRepository.existsById(request.targetId());
             case STORY -> storyRepository.existsById(request.targetId());
-            case PROFILE -> userRepository.existsById(request.targetId());
+            case PROFILE -> userRepository.findByHandleAndDeletedAtIsNull(normalizeTargetHandle(request)).isPresent();
         };
 
         if (!exists) {
             throw new CustomException(ErrorCode.REPORT_TARGET_NOT_FOUND);
         }
+    }
+
+    private String normalizeTargetHandle(ReportCreateRequest request) {
+        return request.targetHandle() == null ? null : request.targetHandle().trim();
+    }
+
+    private Long resolveTargetId(ReportCreateRequest request) {
+        return request.targetType() == ReportTargetType.PROFILE
+                ? null
+                : request.targetId();
+    }
+
+    private String resolveTargetHandle(ReportCreateRequest request) {
+        return request.targetType() == ReportTargetType.PROFILE
+                ? normalizeTargetHandle(request)
+                : null;
     }
 }

--- a/src/test/java/com/gbsw/snapy/domain/reports/service/ReportServiceTest.java
+++ b/src/test/java/com/gbsw/snapy/domain/reports/service/ReportServiceTest.java
@@ -8,6 +8,7 @@ import com.gbsw.snapy.domain.reports.entity.ReportReason;
 import com.gbsw.snapy.domain.reports.entity.ReportTargetType;
 import com.gbsw.snapy.domain.reports.repository.ReportRepository;
 import com.gbsw.snapy.domain.stories.repository.StoryRepository;
+import com.gbsw.snapy.domain.users.entity.User;
 import com.gbsw.snapy.domain.users.repository.UserRepository;
 import com.gbsw.snapy.global.exception.CustomException;
 import com.gbsw.snapy.global.exception.ErrorCode;
@@ -17,6 +18,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -48,6 +51,7 @@ class ReportServiceTest {
         ReportCreateRequest request = new ReportCreateRequest(
                 ReportTargetType.FEED,
                 10L,
+                null,
                 ReportReason.SPAM_OR_SCAM
         );
         when(dailyAlbumRepository.existsById(10L)).thenReturn(true);
@@ -61,9 +65,11 @@ class ReportServiceTest {
         assertThat(report.getReporterId()).isEqualTo(1L);
         assertThat(report.getTargetType()).isEqualTo(ReportTargetType.FEED);
         assertThat(report.getTargetId()).isEqualTo(10L);
+        assertThat(report.getTargetHandle()).isNull();
         assertThat(report.getReason()).isEqualTo(ReportReason.SPAM_OR_SCAM);
         assertThat(response.targetType()).isEqualTo(ReportTargetType.FEED);
         assertThat(response.targetId()).isEqualTo(10L);
+        assertThat(response.targetHandle()).isNull();
         assertThat(response.reason()).isEqualTo(ReportReason.SPAM_OR_SCAM);
     }
 
@@ -72,6 +78,7 @@ class ReportServiceTest {
         ReportCreateRequest request = new ReportCreateRequest(
                 ReportTargetType.STORY,
                 20L,
+                null,
                 ReportReason.FALSE_INFORMATION
         );
         when(storyRepository.existsById(20L)).thenReturn(true);
@@ -88,17 +95,22 @@ class ReportServiceTest {
     void createSavesProfileReport() {
         ReportCreateRequest request = new ReportCreateRequest(
                 ReportTargetType.PROFILE,
-                30L,
+                null,
+                "snapy",
                 ReportReason.OTHER
         );
-        when(userRepository.existsById(30L)).thenReturn(true);
+        when(userRepository.findByHandleAndDeletedAtIsNull("snapy")).thenReturn(Optional.of(new User()));
         when(reportRepository.save(any(Report.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         ReportCreateResponse response = reportService.create(1L, request);
 
-        verify(reportRepository).save(any(Report.class));
+        ArgumentCaptor<Report> captor = ArgumentCaptor.forClass(Report.class);
+        verify(reportRepository).save(captor.capture());
+        assertThat(captor.getValue().getTargetId()).isNull();
+        assertThat(captor.getValue().getTargetHandle()).isEqualTo("snapy");
         assertThat(response.targetType()).isEqualTo(ReportTargetType.PROFILE);
-        assertThat(response.targetId()).isEqualTo(30L);
+        assertThat(response.targetId()).isNull();
+        assertThat(response.targetHandle()).isEqualTo("snapy");
     }
 
     @Test
@@ -106,6 +118,7 @@ class ReportServiceTest {
         ReportCreateRequest request = new ReportCreateRequest(
                 ReportTargetType.FEED,
                 999L,
+                null,
                 ReportReason.OTHER
         );
         when(dailyAlbumRepository.existsById(999L)).thenReturn(false);


### PR DESCRIPTION
### Type of PR
refactor
### Changes
- 프로필 신고 요청/저장 대상을 userId에서 userHandle로 변경
- PROFILE 신고 시 targetHandle 필수 검증 추가
- targetHandle 기준으로 삭제되지 않은 사용자 존재 여부 검증
### Additional
- close #198 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 신고 기능에서 프로필 대상 식별 방식 개선 - 사용자 핸들 기반 지원 추가
  * 신고 대상 유형에 따른 유효성 검증 강화 - 더 정확한 대상 정보 확인

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-snapy/Server/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->