### PR TITLE
fix: 프로필 신고 저장 시 targetId 누락 수정

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/reports/dto/response/ReportCreateResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/reports/dto/response/ReportCreateResponse.java
@@ -15,7 +15,7 @@ public record ReportCreateResponse(
         return new ReportCreateResponse(
                 report.getId(),
                 report.getTargetType(),
-                report.getTargetId(),
+                report.getTargetType() == ReportTargetType.PROFILE ? null : report.getTargetId(),
                 report.getUserHandle(),
                 report.getReason()
         );

--- a/src/main/java/com/gbsw/snapy/domain/reports/service/ReportService.java
+++ b/src/main/java/com/gbsw/snapy/domain/reports/service/ReportService.java
@@ -7,6 +7,7 @@ import com.gbsw.snapy.domain.reports.entity.Report;
 import com.gbsw.snapy.domain.reports.entity.ReportTargetType;
 import com.gbsw.snapy.domain.reports.repository.ReportRepository;
 import com.gbsw.snapy.domain.stories.repository.StoryRepository;
+import com.gbsw.snapy.domain.users.entity.User;
 import com.gbsw.snapy.domain.users.repository.UserRepository;
 import com.gbsw.snapy.global.exception.CustomException;
 import com.gbsw.snapy.global.exception.ErrorCode;
@@ -25,12 +26,12 @@ public class ReportService {
 
     @Transactional
     public ReportCreateResponse create(Long reporterId, ReportCreateRequest request) {
-        validateTargetExists(request);
+        User profileTarget = validateTargetExists(request);
 
         Report report = reportRepository.save(Report.builder()
                 .reporterId(reporterId)
                 .targetType(request.targetType())
-                .targetId(resolveTargetId(request))
+                .targetId(resolveTargetId(request, profileTarget))
                 .userHandle(resolveUserHandle(request))
                 .reason(request.reason())
                 .build());
@@ -38,25 +39,32 @@ public class ReportService {
         return ReportCreateResponse.from(report);
     }
 
-    private void validateTargetExists(ReportCreateRequest request) {
-        boolean exists = switch (request.targetType()) {
-            case FEED -> dailyAlbumRepository.existsById(request.targetId());
-            case STORY -> storyRepository.existsById(request.targetId());
-            case PROFILE -> userRepository.findByHandleAndDeletedAtIsNull(normalizeTargetHandle(request)).isPresent();
+    private User validateTargetExists(ReportCreateRequest request) {
+        return switch (request.targetType()) {
+            case FEED -> {
+                if (!dailyAlbumRepository.existsById(request.targetId())) {
+                    throw new CustomException(ErrorCode.REPORT_TARGET_NOT_FOUND);
+                }
+                yield null;
+            }
+            case STORY -> {
+                if (!storyRepository.existsById(request.targetId())) {
+                    throw new CustomException(ErrorCode.REPORT_TARGET_NOT_FOUND);
+                }
+                yield null;
+            }
+            case PROFILE -> userRepository.findByHandleAndDeletedAtIsNull(normalizeTargetHandle(request))
+                    .orElseThrow(() -> new CustomException(ErrorCode.REPORT_TARGET_NOT_FOUND));
         };
-
-        if (!exists) {
-            throw new CustomException(ErrorCode.REPORT_TARGET_NOT_FOUND);
-        }
     }
 
     private String normalizeTargetHandle(ReportCreateRequest request) {
         return request.userHandle() == null ? null : request.userHandle().trim();
     }
 
-    private Long resolveTargetId(ReportCreateRequest request) {
+    private Long resolveTargetId(ReportCreateRequest request, User profileTarget) {
         return request.targetType() == ReportTargetType.PROFILE
-                ? null
+                ? profileTarget.getId()
                 : request.targetId();
     }
 

--- a/src/test/java/com/gbsw/snapy/domain/reports/service/ReportServiceTest.java
+++ b/src/test/java/com/gbsw/snapy/domain/reports/service/ReportServiceTest.java
@@ -99,14 +99,14 @@ class ReportServiceTest {
                 "snapy",
                 ReportReason.OTHER
         );
-        when(userRepository.findByHandleAndDeletedAtIsNull("snapy")).thenReturn(Optional.of(new User()));
+        when(userRepository.findByHandleAndDeletedAtIsNull("snapy")).thenReturn(Optional.of(User.builder().id(30L).build()));
         when(reportRepository.save(any(Report.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         ReportCreateResponse response = reportService.create(1L, request);
 
         ArgumentCaptor<Report> captor = ArgumentCaptor.forClass(Report.class);
         verify(reportRepository).save(captor.capture());
-        assertThat(captor.getValue().getTargetId()).isNull();
+        assertThat(captor.getValue().getTargetId()).isEqualTo(30L);
         assertThat(captor.getValue().getUserHandle()).isEqualTo("snapy");
         assertThat(response.targetType()).isEqualTo(ReportTargetType.PROFILE);
         assertThat(response.targetId()).isNull();
@@ -121,13 +121,14 @@ class ReportServiceTest {
                 " snapy ",
                 ReportReason.OTHER
         );
-        when(userRepository.findByHandleAndDeletedAtIsNull("snapy")).thenReturn(Optional.of(new User()));
+        when(userRepository.findByHandleAndDeletedAtIsNull("snapy")).thenReturn(Optional.of(User.builder().id(30L).build()));
         when(reportRepository.save(any(Report.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         ReportCreateResponse response = reportService.create(1L, request);
 
         ArgumentCaptor<Report> captor = ArgumentCaptor.forClass(Report.class);
         verify(reportRepository).save(captor.capture());
+        assertThat(captor.getValue().getTargetId()).isEqualTo(30L);
         assertThat(captor.getValue().getUserHandle()).isEqualTo("snapy");
         assertThat(response.userHandle()).isEqualTo("snapy");
     }


### PR DESCRIPTION
### Type of PR
fix
### Changes
- 프로필 신고 시 userHandle로 대상 사용자 조회
- 조회된 사용자 id를 reports.target_id에 저장하도록 수정
- userHandle은 기존 target_handle 컬럼에 함께 저장
- 프로필 신고 응답에서는 targetId를 숨기고 userHandle만 반환
- 프로필 신고 저장/검증 테스트 보강
### Additional
- close #206 