### PR TITLE
feat: apple-app-site-association 엔드포인트 추가

### DIFF
--- a/src/main/java/com/gbsw/snapy/global/security/SecurityConfig.java
+++ b/src/main/java/com/gbsw/snapy/global/security/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/v3/api-docs/**",
             "/swagger-ui.html",
-            "/api/health"
+            "/api/health",
+            "/.well-known/apple-app-site-association"
     };
 
     @Bean

--- a/src/main/java/com/gbsw/snapy/global/wellknown/AppleAppSiteAssociationController.java
+++ b/src/main/java/com/gbsw/snapy/global/wellknown/AppleAppSiteAssociationController.java
@@ -1,0 +1,34 @@
+package com.gbsw.snapy.global.wellknown;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AppleAppSiteAssociationController {
+
+    private static final String APPLE_APP_SITE_ASSOCIATION = """
+            {
+              "applinks": {
+                "apps": [],
+                "details": [
+                  {
+                    "appID": "QLF22M2925.com.messiofcoding.snapy",
+                    "paths": ["*"]
+                  }
+                ]
+              }
+            }
+            """;
+
+    @GetMapping(
+            value = "/.well-known/apple-app-site-association",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<String> getAppleAppSiteAssociation() {
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(APPLE_APP_SITE_ASSOCIATION);
+    }
+}


### PR DESCRIPTION
### Type of PR
feat
### Changes
- Universal Links용 apple-app-site-association 엔드포인트 추가
- /.well-known/apple-app-site-association 경로를 인증 없이 공개 접근 가능하도록 설정
- 응답 Content-Type을 application/json으로 지정
### Additional
- JSON을 직접 반환
- close #212 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Apple App Site Association 엔드포인트가 새로 추가되었습니다. 이 엔드포인트는 인증 없이 공개적으로 접근 가능하며 JSON 형식의 응답을 제공합니다. 관련 보안 설정도 함께 업데이트되어 해당 경로가 공개 접근으로 처리되도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->