### PR TITLE
feat: 프로필 조회에 과거 앨범 요약 추가

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/albums/dto/response/ProfilePastAlbumResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/dto/response/ProfilePastAlbumResponse.java
@@ -1,0 +1,8 @@
+package com.gbsw.snapy.domain.albums.dto.response;
+
+public record ProfilePastAlbumResponse(
+        int year,
+        int month,
+        String thumbnailUrl
+) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
+++ b/src/main/java/com/gbsw/snapy/domain/albums/service/AlbumQueryService.java
@@ -4,6 +4,7 @@ import com.gbsw.snapy.domain.albums.dto.response.AlbumDetailResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumLikeListResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumListResponse;
 import com.gbsw.snapy.domain.albums.dto.response.AlbumTodayResponse;
+import com.gbsw.snapy.domain.albums.dto.response.ProfilePastAlbumResponse;
 import com.gbsw.snapy.domain.albums.entity.AlbumPhoto;
 import com.gbsw.snapy.domain.albums.entity.AlbumPhotoType;
 import com.gbsw.snapy.domain.albums.entity.AlbumStatus;
@@ -33,6 +34,7 @@ import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
@@ -217,6 +219,49 @@ public class AlbumQueryService {
         List<DailyAlbum> albums = dailyAlbumRepository
                 .findByUserIdAndAlbumDateBetweenOrderByAlbumDateDesc(userId, fiveMonthsAgo, today);
         return buildAlbumListResponses(albums);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProfilePastAlbumResponse> getProfilePastAlbums(Long targetUserId, Long requesterId) {
+        YearMonth currentMonth = YearMonth.now(KST_ZONE);
+        YearMonth lastPastMonth = currentMonth.minusMonths(1);
+        if (lastPastMonth.isBefore(YearMonth.of(currentMonth.getYear(), 1))) {
+            return List.of();
+        }
+
+        if (!targetUserId.equals(requesterId)) {
+            if (userBlockRepository.existsBlockBetween(requesterId, targetUserId)) {
+                return List.of();
+            }
+
+            UserSetting setting = userSettingRepository.findById(targetUserId).orElse(null);
+            Visibility visibility = (setting != null) ? setting.getPastAlbumVisibility() : Visibility.FRIENDS_ONLY;
+            if (visibility == Visibility.ONLY_ME) {
+                return List.of();
+            }
+            if (visibility == Visibility.FRIENDS_ONLY
+                    && !friendRepository.existsFriendship(requesterId, targetUserId)) {
+                return List.of();
+            }
+        }
+
+        LocalDate start = YearMonth.of(currentMonth.getYear(), 1).atDay(1);
+        LocalDate end = lastPastMonth.atEndOfMonth();
+        List<DailyAlbum> albums = dailyAlbumRepository
+                .findByUserIdAndStatusAndAlbumDateBetweenOrderByAlbumDateDesc(
+                        targetUserId, AlbumStatus.PUBLISHED, start, end);
+        List<AlbumListResponse> albumResponses = buildAlbumListResponses(albums);
+
+        Map<YearMonth, ProfilePastAlbumResponse> pastAlbums = new LinkedHashMap<>();
+        for (AlbumListResponse album : albumResponses) {
+            YearMonth albumMonth = YearMonth.from(album.albumDate());
+            pastAlbums.putIfAbsent(albumMonth, new ProfilePastAlbumResponse(
+                    albumMonth.getYear(),
+                    albumMonth.getMonthValue(),
+                    album.thumbnailUrl()
+            ));
+        }
+        return new ArrayList<>(pastAlbums.values());
     }
 
     private List<AlbumListResponse> buildAlbumListResponses(List<DailyAlbum> albums) {

--- a/src/main/java/com/gbsw/snapy/domain/users/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/users/dto/response/UserProfileResponse.java
@@ -1,6 +1,9 @@
 package com.gbsw.snapy.domain.users.dto.response;
 
+import com.gbsw.snapy.domain.albums.dto.response.ProfilePastAlbumResponse;
 import com.gbsw.snapy.domain.users.entity.User;
+
+import java.util.List;
 
 public record UserProfileResponse(
         String handle,
@@ -11,7 +14,8 @@ public record UserProfileResponse(
         int currentStreak,
         int maxStreak,
         boolean blocked,
-        boolean blockedBy
+        boolean blockedBy,
+        List<ProfilePastAlbumResponse> pastAlbums
 ) {
     public static UserProfileResponse from(
             User user,
@@ -19,7 +23,8 @@ public record UserProfileResponse(
             int currentStreak,
             int maxStreak,
             boolean blocked,
-            boolean blockedBy
+            boolean blockedBy,
+            List<ProfilePastAlbumResponse> pastAlbums
     ) {
         return new UserProfileResponse(
                 user.getHandle(),
@@ -30,7 +35,8 @@ public record UserProfileResponse(
                 currentStreak,
                 maxStreak,
                 blocked,
-                blockedBy
+                blockedBy,
+                pastAlbums
         );
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/users/service/UserService.java
+++ b/src/main/java/com/gbsw/snapy/domain/users/service/UserService.java
@@ -1,5 +1,7 @@
 package com.gbsw.snapy.domain.users.service;
 
+import com.gbsw.snapy.domain.albums.dto.response.ProfilePastAlbumResponse;
+import com.gbsw.snapy.domain.albums.service.AlbumQueryService;
 import com.gbsw.snapy.domain.users.dto.request.UpdateHandleRequest;
 import com.gbsw.snapy.domain.users.dto.request.UpdatePhoneRequest;
 import com.gbsw.snapy.domain.users.dto.request.UpdateUsernameRequest;
@@ -36,6 +38,7 @@ public class UserService {
     private final S3Service s3Service;
     private final StreakService streakService;
     private final PhoneVerificationService phoneVerificationService;
+    private final AlbumQueryService albumQueryService;
 
     public UserProfileResponse getProfile(String handle, Long viewerId) {
         User user = userRepository.findByHandleAndDeletedAtIsNull(handle)
@@ -50,7 +53,9 @@ public class UserService {
             blockedBy = userBlockRepository.existsById_UserIdAndId_TargetUserId(user.getId(), viewerId);
         }
 
-        return UserProfileResponse.from(user, friendCount, streak.current(), streak.max(), blocked, blockedBy);
+        List<ProfilePastAlbumResponse> pastAlbums = albumQueryService.getProfilePastAlbums(user.getId(), viewerId);
+        return UserProfileResponse.from(
+                user, friendCount, streak.current(), streak.max(), blocked, blockedBy, pastAlbums);
     }
 
     public UserProfileResponse getMyProfile(Long userId) {
@@ -58,7 +63,9 @@ public class UserService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         long friendCount = friendRepository.countFriendsByUserId(userId);
         StreakService.StreakSummary streak = streakService.getSummary(userId);
-        return UserProfileResponse.from(user, friendCount, streak.current(), streak.max(), false, false);
+        List<ProfilePastAlbumResponse> pastAlbums = albumQueryService.getProfilePastAlbums(userId, userId);
+        return UserProfileResponse.from(
+                user, friendCount, streak.current(), streak.max(), false, false, pastAlbums);
     }
 
     public UpdateBackgroundImageResponse updateBackgroundImage(Long userId, MultipartFile file) {


### PR DESCRIPTION
### Type of PR
feat
### Changes
- 프로필 응답에 pastAlbums 필드 추가
- 과거 앨범을 연/월 단위로 묶어 대표 썸네일 반환
- 타인 프로필 조회 시 pastAlbumVisibility와 친구/차단 관계 반영
### Additional
- 공개 범위가 맞지 않는 경우 pastAlbums는 빈 배열로 반환
- close #215 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 프로필에 과거 앨범 목록이 표시됩니다. 각 앨범에서 연도, 월, 썸네일 정보를 확인할 수 있습니다.
  * 차단 상태, 앨범 공개 범위 설정, 친구 관계를 검증하여 사용자의 프라이버시를 보호합니다.
  * 현재 연도부터 최근 지난 달까지의 게시된 앨범을 월별로 조회합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->