### PR TITLE
feat: 유저 프로필 응답에 공개 범위 필드 추가

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/users/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/users/dto/response/UserProfileResponse.java
@@ -1,6 +1,7 @@
 package com.gbsw.snapy.domain.users.dto.response;
 
 import com.gbsw.snapy.domain.albums.dto.response.ProfilePastAlbumResponse;
+import com.gbsw.snapy.domain.settings.entity.Visibility;
 import com.gbsw.snapy.domain.users.entity.User;
 
 import java.util.List;
@@ -15,6 +16,8 @@ public record UserProfileResponse(
         int maxStreak,
         boolean blocked,
         boolean blockedBy,
+        Visibility feedVisibility,
+        Visibility pastAlbumVisibility,
         List<ProfilePastAlbumResponse> pastAlbums
 ) {
     public static UserProfileResponse from(
@@ -24,6 +27,8 @@ public record UserProfileResponse(
             int maxStreak,
             boolean blocked,
             boolean blockedBy,
+            Visibility feedVisibility,
+            Visibility pastAlbumVisibility,
             List<ProfilePastAlbumResponse> pastAlbums
     ) {
         return new UserProfileResponse(
@@ -36,6 +41,8 @@ public record UserProfileResponse(
                 maxStreak,
                 blocked,
                 blockedBy,
+                feedVisibility,
+                pastAlbumVisibility,
                 pastAlbums
         );
     }

--- a/src/main/java/com/gbsw/snapy/domain/users/service/UserService.java
+++ b/src/main/java/com/gbsw/snapy/domain/users/service/UserService.java
@@ -2,6 +2,9 @@ package com.gbsw.snapy.domain.users.service;
 
 import com.gbsw.snapy.domain.albums.dto.response.ProfilePastAlbumResponse;
 import com.gbsw.snapy.domain.albums.service.AlbumQueryService;
+import com.gbsw.snapy.domain.settings.entity.UserSetting;
+import com.gbsw.snapy.domain.settings.entity.Visibility;
+import com.gbsw.snapy.domain.settings.repository.UserSettingRepository;
 import com.gbsw.snapy.domain.users.dto.request.UpdateHandleRequest;
 import com.gbsw.snapy.domain.users.dto.request.UpdatePhoneRequest;
 import com.gbsw.snapy.domain.users.dto.request.UpdateUsernameRequest;
@@ -39,6 +42,7 @@ public class UserService {
     private final StreakService streakService;
     private final PhoneVerificationService phoneVerificationService;
     private final AlbumQueryService albumQueryService;
+    private final UserSettingRepository userSettingRepository;
 
     public UserProfileResponse getProfile(String handle, Long viewerId) {
         User user = userRepository.findByHandleAndDeletedAtIsNull(handle)
@@ -54,8 +58,10 @@ public class UserService {
         }
 
         List<ProfilePastAlbumResponse> pastAlbums = albumQueryService.getProfilePastAlbums(user.getId(), viewerId);
+        UserSetting setting = getUserSetting(user.getId());
         return UserProfileResponse.from(
-                user, friendCount, streak.current(), streak.max(), blocked, blockedBy, pastAlbums);
+                user, friendCount, streak.current(), streak.max(), blocked, blockedBy,
+                feedVisibility(setting), pastAlbumVisibility(setting), pastAlbums);
     }
 
     public UserProfileResponse getMyProfile(Long userId) {
@@ -64,8 +70,10 @@ public class UserService {
         long friendCount = friendRepository.countFriendsByUserId(userId);
         StreakService.StreakSummary streak = streakService.getSummary(userId);
         List<ProfilePastAlbumResponse> pastAlbums = albumQueryService.getProfilePastAlbums(userId, userId);
+        UserSetting setting = getUserSetting(userId);
         return UserProfileResponse.from(
-                user, friendCount, streak.current(), streak.max(), false, false, pastAlbums);
+                user, friendCount, streak.current(), streak.max(), false, false,
+                feedVisibility(setting), pastAlbumVisibility(setting), pastAlbums);
     }
 
     public UpdateBackgroundImageResponse updateBackgroundImage(Long userId, MultipartFile file) {
@@ -173,5 +181,17 @@ public class UserService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         user.setUsername(request.getUsername());
+    }
+
+    private UserSetting getUserSetting(Long userId) {
+        return userSettingRepository.findById(userId).orElse(null);
+    }
+
+    private Visibility feedVisibility(UserSetting setting) {
+        return setting != null ? setting.getFeedVisibility() : Visibility.FRIENDS_ONLY;
+    }
+
+    private Visibility pastAlbumVisibility(UserSetting setting) {
+        return setting != null ? setting.getPastAlbumVisibility() : Visibility.FRIENDS_ONLY;
     }
 }


### PR DESCRIPTION
### Type of PR
feat
### Changes
- GET /api/users/{handle} 프로필 응답에 feedVisibility, pastAlbumVisibility 추가
- UserService에서 대상 유저의 UserSetting을 조회해 공개 범위 값 반환
- UserSetting이 없는 경우 기본값 FRIENDS_ONLY 반환
### Additional
- UserProfileResponse를 공유하는 /api/users/me 응답에도 동일 필드가 포함됨
- close #219 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 사용자 프로필 조회 시 피드 및 과거 앨범의 가시성 정보를 API 응답에 포함하도록 추가되었습니다. 사용자가 설정한 공개 범위 정보가 프로필 정보와 함께 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->