### PR TITLE
chore: EC2 배포 인증을 비밀번호에서 SSH 키 방식으로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
-          password: ${{ secrets.EC2_PASSWORD }}
+          key: ${{ secrets.EC2_SSH_KEY }}
           source: "docker-compose.yml"
           target: ${{ env.REMOTE_APP_DIR }}
 
@@ -107,7 +107,7 @@ jobs:
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
-          password: ${{ secrets.EC2_PASSWORD }}
+          key: ${{ secrets.EC2_SSH_KEY }}
           envs: GHCR_USER,GHCR_TOKEN,DB_USERNAME,DB_PASSWORD,JWT_SECRET_KEY,S3_BUCKET,CLOUDFRONT_URL,IMAGE_NAME,IMAGE_TAG,GRPC_SERVER_HOST,GRPC_SERVER_PORT,GOOGLE_OAUTH_WEB_CLIENT_ID,GOOGLE_OAUTH_WEB_CLIENT_SECRET,GOOGLE_OAUTH_WEB_REDIRECT_URI,GOOGLE_OAUTH_IOS_CLIENT_ID,APPLE_OAUTH_TEAM_ID,APPLE_OAUTH_KEY_ID,APPLE_OAUTH_PRIVATE_KEY,APPLE_OAUTH_BUNDLE_ID,APPLE_OAUTH_SERVICE_ID,APPLE_OAUTH_REDIRECT_URI,APNS_ENABLED,APNS_PRODUCTION,APNS_BUNDLE_ID,FRONTEND_URL,ALIGO_KEY,ALIGO_USER_ID,ALIGO_SENDER,ALIGO_TEST_MODE
           script: |
             set -e
@@ -164,7 +164,7 @@ jobs:
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
-          password: ${{ secrets.EC2_PASSWORD }}
+          key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             echo "Health check 대기 중..."
             for i in $(seq 1 30); do


### PR DESCRIPTION
### Type of PR
chore
### Changes
- GitHub Actions EC2 접속 인증을 비밀번호 방식에서 SSH 키 방식으로 변경
### Additional
- close #224 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 배포 워크플로우의 인증 시스템을 업데이트했습니다. 자동화된 배포 과정에서 서버 접속, 구성 파일 전송, 컨테이너 교체, 헬스 체크 등 각 단계에서 사용되는 인증 방식이 변경되었습니다. 배포 절차의 인증 처리가 일관되게 수정되었으며 관련 시크릿 설정도 함께 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->