### PR TITLE
feat: Docker Compose에 MySQL 서비스 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,32 @@
 services:
+  db:
+    image: mysql:8.0
+    container_name: snapy-db
+    environment:
+      TZ: Asia/Seoul
+      MYSQL_DATABASE: snapy
+      MYSQL_USER: ${SPRING_DATASOURCE_USERNAME}
+      MYSQL_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --default-time-zone=+09:00
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} --silent"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   app:
     image: ${APP_IMAGE:-ghcr.io/2026-messi-of-coding/server:latest}
     container_name: snapy-app
@@ -13,17 +41,21 @@ services:
       TZ: Asia/Seoul
       LOG_PATH: /app/logs
       SPRING_PROFILES_ACTIVE: deploy
-      SPRING_DATASOURCE_URL: jdbc:mysql://host.docker.internal:3306/snapy?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/snapy?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       SPRING_CLOUD_AWS_REGION_STATIC: ap-northeast-2
       SPRING_JPA_SHOW_SQL: "false"
       SPRING_JPA_PROPERTIES_HIBERNATE_FORMAT_SQL: "false"
       LOGGING_LEVEL_ORG_HIBERNATE_SQL: WARN
       LOGGING_LEVEL_ORG_HIBERNATE_ORM_JDBC_BIND: WARN
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    depends_on:
+      db:
+        condition: service_healthy
     restart: unless-stopped
     logging:
       driver: json-file
       options:
         max-size: "10m"
         max-file: "3"
+
+volumes:
+  mysql-data:


### PR DESCRIPTION
### Type of PR
feat
### Changes
- Spring Boot 서버의 DB 연결 주소를 Compose 내부 db 서비스로 변경
### Additional
- close #227 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Chores**
  * Docker Compose에 데이터베이스 서비스를 추가하고 애플리케이션의 데이터베이스 시작 대기를 구성했습니다.
  * 데이터베이스 데이터 영속 저장을 위한 볼륨 설정을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->