### PR TITLE
chore: docker network 연결 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   db:
     image: mysql:8.0
     container_name: snapy-db
+    networks:
+      - snapy-net
     environment:
       TZ: Asia/Seoul
       MYSQL_DATABASE: snapy
@@ -30,6 +32,8 @@ services:
   app:
     image: ${APP_IMAGE:-ghcr.io/2026-messi-of-coding/server:latest}
     container_name: snapy-app
+    networks:
+      - snapy-net
     ports:
       - "8080:8080"
     volumes:
@@ -59,3 +63,7 @@ services:
 
 volumes:
   mysql-data:
+
+networks:
+  shared-net:
+    external: true


### PR DESCRIPTION
### Type of PR
chore

### Changes

### Additional

close #230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker Compose 네트워크 구성을 업데이트했습니다. 데이터베이스 및 애플리케이션 서비스가 전용 네트워크에 연결되도록 설정되었으며, 외부 네트워크 정의가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->