### PR TITLE
feat: 알림 푸시 활성화 설정 API 추가

### DIFF
--- a/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
+++ b/src/main/java/com/gbsw/snapy/domain/notifications/service/NotificationService.java
@@ -6,6 +6,7 @@ import com.gbsw.snapy.domain.notifications.dto.response.UnreadCountResponse;
 import com.gbsw.snapy.domain.notifications.entity.Notification;
 import com.gbsw.snapy.domain.notifications.entity.NotificationType;
 import com.gbsw.snapy.domain.notifications.repository.NotificationRepository;
+import com.gbsw.snapy.domain.settings.repository.UserSettingRepository;
 import com.gbsw.snapy.domain.users.entity.User;
 import com.gbsw.snapy.domain.users.repository.UserRepository;
 import com.gbsw.snapy.global.exception.CustomException;
@@ -32,6 +33,7 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
+    private final UserSettingRepository userSettingRepository;
     private final ApnsPushService apnsPushService;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -58,7 +60,7 @@ public class NotificationService {
                         .read(false)
                         .build()
         );
-        if (pushEnabled) {
+        if (pushEnabled && isPushEnabled(receiverId)) {
             apnsPushService.sendToUser(receiverId, type);
         }
     }
@@ -86,7 +88,15 @@ public class NotificationService {
         } catch (DataIntegrityViolationException e) {
             return;
         }
-        apnsPushService.sendToUser(receiverId, NotificationType.FEED_LIKE);
+        if (isPushEnabled(receiverId)) {
+            apnsPushService.sendToUser(receiverId, NotificationType.FEED_LIKE);
+        }
+    }
+
+    private boolean isPushEnabled(Long userId) {
+        return userSettingRepository.findById(userId)
+                .map(setting -> setting.isNotificationEnabled())
+                .orElse(true);
     }
 
     private String feedLikeDeduplicationKey(Long receiverId, Long senderId, Long albumId) {

--- a/src/main/java/com/gbsw/snapy/domain/settings/controller/UserSettingController.java
+++ b/src/main/java/com/gbsw/snapy/domain/settings/controller/UserSettingController.java
@@ -2,6 +2,7 @@ package com.gbsw.snapy.domain.settings.controller;
 
 import com.gbsw.snapy.domain.settings.dto.request.UpdatePastAlbumVisibilityRequest;
 import com.gbsw.snapy.domain.settings.dto.request.UpdateFeedVisibilityRequest;
+import com.gbsw.snapy.domain.settings.dto.request.UpdateNotificationEnabledRequest;
 import com.gbsw.snapy.domain.settings.dto.response.UserSettingResponse;
 import com.gbsw.snapy.domain.settings.service.UserSettingService;
 import com.gbsw.snapy.global.common.ApiResponse;
@@ -41,6 +42,15 @@ public class UserSettingController {
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
         userSettingService.updatePastAlbumVisibility(principal.getId(), request);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PatchMapping("/notifications")
+    public ResponseEntity<ApiResponse<Void>> updateNotificationEnabled(
+            @Valid @RequestBody UpdateNotificationEnabledRequest request,
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        userSettingService.updateNotificationEnabled(principal.getId(), request);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/settings/dto/request/UpdateNotificationEnabledRequest.java
+++ b/src/main/java/com/gbsw/snapy/domain/settings/dto/request/UpdateNotificationEnabledRequest.java
@@ -1,0 +1,9 @@
+package com.gbsw.snapy.domain.settings.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateNotificationEnabledRequest(
+        @NotNull(message = "enabled는 필수입니다.")
+        Boolean enabled
+) {
+}

--- a/src/main/java/com/gbsw/snapy/domain/settings/dto/response/UserSettingResponse.java
+++ b/src/main/java/com/gbsw/snapy/domain/settings/dto/response/UserSettingResponse.java
@@ -5,9 +5,14 @@ import com.gbsw.snapy.domain.settings.entity.Visibility;
 
 public record UserSettingResponse(
         Visibility feedVisibility,
-        Visibility pastAlbumVisibility
+        Visibility pastAlbumVisibility,
+        boolean notificationEnabled
 ) {
     public static UserSettingResponse from(UserSetting setting) {
-        return new UserSettingResponse(setting.getFeedVisibility(), setting.getPastAlbumVisibility());
+        return new UserSettingResponse(
+                setting.getFeedVisibility(),
+                setting.getPastAlbumVisibility(),
+                setting.isNotificationEnabled()
+        );
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/settings/entity/UserSetting.java
+++ b/src/main/java/com/gbsw/snapy/domain/settings/entity/UserSetting.java
@@ -2,6 +2,7 @@ package com.gbsw.snapy.domain.settings.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Table(name = "user_settings")
@@ -21,10 +22,15 @@ public class UserSetting {
     @Column(name = "past_album_visibility", nullable = false)
     private Visibility pastAlbumVisibility;
 
+    @Column(name = "notification_enabled", nullable = false)
+    @ColumnDefault("true")
+    private boolean notificationEnabled;
+
     @Builder
     public UserSetting(Long userId) {
         this.userId = userId;
         this.feedVisibility = Visibility.FRIENDS_ONLY;
         this.pastAlbumVisibility = Visibility.FRIENDS_ONLY;
+        this.notificationEnabled = true;
     }
 }

--- a/src/main/java/com/gbsw/snapy/domain/settings/service/UserSettingService.java
+++ b/src/main/java/com/gbsw/snapy/domain/settings/service/UserSettingService.java
@@ -2,6 +2,7 @@ package com.gbsw.snapy.domain.settings.service;
 
 import com.gbsw.snapy.domain.settings.dto.request.UpdatePastAlbumVisibilityRequest;
 import com.gbsw.snapy.domain.settings.dto.request.UpdateFeedVisibilityRequest;
+import com.gbsw.snapy.domain.settings.dto.request.UpdateNotificationEnabledRequest;
 import com.gbsw.snapy.domain.settings.dto.response.UserSettingResponse;
 import com.gbsw.snapy.domain.settings.entity.UserSetting;
 import com.gbsw.snapy.domain.settings.entity.Visibility;
@@ -44,6 +45,12 @@ public class UserSettingService {
         }
         UserSetting setting = getOrCreate(userId);
         setting.setPastAlbumVisibility(request.visibility());
+    }
+
+    @Transactional
+    public void updateNotificationEnabled(Long userId, UpdateNotificationEnabledRequest request) {
+        UserSetting setting = getOrCreate(userId);
+        setting.setNotificationEnabled(request.enabled());
     }
 
     private UserSetting getOrCreate(Long userId) {

--- a/src/test/java/com/gbsw/snapy/domain/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/com/gbsw/snapy/domain/notifications/service/NotificationServiceTest.java
@@ -3,6 +3,8 @@ package com.gbsw.snapy.domain.notifications.service;
 import com.gbsw.snapy.domain.notifications.entity.Notification;
 import com.gbsw.snapy.domain.notifications.entity.NotificationType;
 import com.gbsw.snapy.domain.notifications.repository.NotificationRepository;
+import com.gbsw.snapy.domain.settings.entity.UserSetting;
+import com.gbsw.snapy.domain.settings.repository.UserSettingRepository;
 import com.gbsw.snapy.domain.users.repository.UserRepository;
 import com.gbsw.snapy.infra.apns.ApnsPushService;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationServiceTest {
@@ -27,6 +30,9 @@ class NotificationServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private UserSettingRepository userSettingRepository;
 
     @Mock
     private ApnsPushService apnsPushService;
@@ -87,6 +93,31 @@ class NotificationServiceTest {
 
         notificationService.createFeedLikeIfAbsent(1L, 2L, 100L, 10L);
 
+        verify(apnsPushService, never()).sendToUser(any(), any());
+    }
+
+    @Test
+    void createSkipsPushWhenNotificationsAreDisabled() {
+        UserSetting setting = UserSetting.builder().userId(1L).build();
+        setting.setNotificationEnabled(false);
+        when(userSettingRepository.findById(1L)).thenReturn(Optional.of(setting));
+
+        notificationService.create(1L, 2L, NotificationType.FRIEND_REQUEST, 10L, null);
+
+        verify(notificationRepository).save(any(Notification.class));
+        verify(apnsPushService, never()).sendToUser(any(), any());
+    }
+
+    @Test
+    void createFeedLikeIfAbsentSkipsPushWhenNotificationsAreDisabled() {
+        UserSetting setting = UserSetting.builder().userId(1L).build();
+        setting.setNotificationEnabled(false);
+        when(notificationRepository.existsByDeduplicationKey("FEED_LIKE:1:2:10")).thenReturn(false);
+        when(userSettingRepository.findById(1L)).thenReturn(Optional.of(setting));
+
+        notificationService.createFeedLikeIfAbsent(1L, 2L, 100L, 10L);
+
+        verify(notificationRepository).saveAndFlush(any(Notification.class));
         verify(apnsPushService, never()).sendToUser(any(), any());
     }
 }

--- a/src/test/java/com/gbsw/snapy/domain/settings/service/UserSettingServiceTest.java
+++ b/src/test/java/com/gbsw/snapy/domain/settings/service/UserSettingServiceTest.java
@@ -1,0 +1,35 @@
+package com.gbsw.snapy.domain.settings.service;
+
+import com.gbsw.snapy.domain.settings.dto.request.UpdateNotificationEnabledRequest;
+import com.gbsw.snapy.domain.settings.entity.UserSetting;
+import com.gbsw.snapy.domain.settings.repository.UserSettingRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserSettingServiceTest {
+
+    @Mock
+    private UserSettingRepository userSettingRepository;
+
+    @InjectMocks
+    private UserSettingService userSettingService;
+
+    @Test
+    void updateNotificationEnabledDisablesPushNotifications() {
+        UserSetting setting = UserSetting.builder().userId(1L).build();
+        when(userSettingRepository.findById(1L)).thenReturn(Optional.of(setting));
+
+        userSettingService.updateNotificationEnabled(1L, new UpdateNotificationEnabledRequest(false));
+
+        assertThat(setting.isNotificationEnabled()).isFalse();
+    }
+}


### PR DESCRIPTION
### Type of PR
feat
### Changes
- 사용자 설정에 notificationEnabled 필드 추가
- 알림 푸시 활성화 상태 변경 API 추가
- 설정 조회 응답에 notificationEnabled 포함
### Additional
- 알림을 비활성화해도 인앱 알림은 저장되며 APNs 푸시만 발송되지 않음
- close #235 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자가 푸시 알림을 활성화 또는 비활성화할 수 있는 알림 설정 기능이 추가되었습니다.
  * 사용자의 알림 설정 선호도에 따라 모든 푸시 알림 전송이 자동으로 제어됩니다.

* **Tests**
  * 알림 설정 기능의 동작을 검증하는 테스트 코드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->