### PR TITLE
feat: 오디오 필터링에 .webm 허용

### DIFF
--- a/src/main/java/com/gbsw/snapy/infra/s3/S3Service.java
+++ b/src/main/java/com/gbsw/snapy/infra/s3/S3Service.java
@@ -103,8 +103,13 @@ public class S3Service {
             throw new CustomException(ErrorCode.AUDIO_EMPTY);
         }
 
+    List<String> allowedContentTypes = List.of(".m4a", ".webm");
         String originalFilename = file.getOriginalFilename();
-        if (originalFilename == null || !originalFilename.toLowerCase().endsWith(".m4a")) {
+        if (originalFilename == null) {
+            throw new CustomException(ErrorCode.INVALID_AUDIO_TYPE);
+        }
+        String lowerFilename = originalFilename.toLowerCase();
+        if (allowedContentTypes.stream().noneMatch(lowerFilename::endsWith)) {
             throw new CustomException(ErrorCode.INVALID_AUDIO_TYPE);
         }
 


### PR DESCRIPTION
### Type of PR
feat

### Changes
오디오 필터링에 .webm 허용

### Additional

close #252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 오디오 파일 업로드 시 허용 확장자 검증이 개선되어, `.m4a`와 `.webm` 파일을 허용합니다.
  * 파일명이 없거나 허용되지 않은 형식이면 기존과 동일하게 잘못된 오디오 형식 오류가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->